### PR TITLE
First stab at Airlflow

### DIFF
--- a/deployment/plat-infra-services/airflow/community/README.md
+++ b/deployment/plat-infra-services/airflow/community/README.md
@@ -1,0 +1,63 @@
+Airflow
+-------
+> a work in progress!
+
+
+### Helm chart
+
+As an alternative to the official chart, the community-maintained
+one looks much better:
+- https://github.com/airflow-helm/charts
+
+We're using version `8.7.1` of this chart
+- https://github.com/airflow-helm/charts/tree/airflow-8.7.1/charts/airflow
+
+Our values file is a tweaked version of the K8s executor example
+- https://github.com/airflow-helm/charts/blob/airflow-8.7.1/charts/airflow/sample-values-KubernetesExecutor.yaml
+
+But it didn't work for us---at least version `8.7.1` of that chart.
+The values file we used was basically identical to their K8s executor
+example, except for the Postgres volume where we specified the DirectPV
+storage class and 1GB storage claim.
+
+
+### Deployment
+
+Manual procedure for now, we'll hook it into Argo CD later.
+
+Get a Nix shell, set your K8s config for the target cluster and cd
+into the Airflow deployment dir
+
+```bash
+$ cd nix
+$ nix shell
+$ export KUBECONFIG=/your/cluster/k8s/config.yaml
+$ cd ../deployment/plat-infra-services/airflow
+```
+
+Add the Helm repo and update the cache
+
+```bash
+$ helm repo add airflow-stable https://airflow-helm.github.io/charts
+$ helm repo update
+```
+
+Then install the `8.7.1` version of the chart with our config
+
+```bash
+$ kubectl apply -f namespace.yaml
+$ helm install airflow airflow-stable/airflow \
+    --namespace airflow \
+    --version "8.7.1" \
+    --values ./helm-values.yaml
+```
+
+
+### debug
+
+helm template airflow airflow-stable/airflow \
+  --namespace airflow \
+  --version "8.7.1" \
+  --values ./helm-values.yaml > out.yaml
+
+helm uninstall airflow --namespace airflow

--- a/deployment/plat-infra-services/airflow/community/git.yaml
+++ b/deployment/plat-infra-services/airflow/community/git.yaml
@@ -1,0 +1,2249 @@
+########################################
+## CONFIG | Airflow Configs
+########################################
+airflow:
+  ## if we use legacy 1.10 airflow commands
+  ##
+  legacyCommands: false
+
+  ## configs for the airflow container image
+  ##
+  image:
+    repository: apache/airflow
+    tag: 2.5.3-python3.8
+    pullPolicy: IfNotPresent
+    pullSecret: ""
+    uid: 50000
+    gid: 0
+
+  ## the airflow executor type to use
+  ## - allowed values: "CeleryExecutor", "KubernetesExecutor", "CeleryKubernetesExecutor"
+  ## - customize the "KubernetesExecutor" pod-template with `airflow.kubernetesPodTemplate.*`
+  ##
+  executor: CeleryExecutor
+
+  ## the fernet encryption key (sets `AIRFLOW__CORE__FERNET_KEY`)
+  ## - [WARNING] you must change this value to ensure the security of your airflow
+  ## - set `AIRFLOW__CORE__FERNET_KEY` with `airflow.extraEnv` from a Secret to avoid storing this in your values
+  ## - use this command to generate your own fernet key:
+  ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
+  ##
+  fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
+
+  ## the secret_key for flask (sets `AIRFLOW__WEBSERVER__SECRET_KEY`)
+  ## - [WARNING] you must change this value to ensure the security of your airflow
+  ## - set `AIRFLOW__WEBSERVER__SECRET_KEY` with `airflow.extraEnv` from a Secret to avoid storing this in your values
+  ##
+  webserverSecretKey: "THIS IS UNSAFE!"
+
+  ## environment variables for airflow configs
+  ## - airflow env-vars are structured: "AIRFLOW__{config_section}__{config_name}"
+  ## - airflow configuration reference:
+  ##   https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html
+  ##
+  ## ____ EXAMPLE _______________
+  ##   config:
+  ##     # dag configs
+  ##     AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+  ##     AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "30"
+  ##
+  ##     # email configs
+  ##     AIRFLOW__EMAIL__EMAIL_BACKEND: "airflow.utils.email.send_email_smtp"
+  ##     AIRFLOW__SMTP__SMTP_HOST: "smtpmail.example.com"
+  ##     AIRFLOW__SMTP__SMTP_MAIL_FROM: "admin@example.com"
+  ##     AIRFLOW__SMTP__SMTP_PORT: "25"
+  ##     AIRFLOW__SMTP__SMTP_SSL: "False"
+  ##     AIRFLOW__SMTP__SMTP_STARTTLS: "False"
+  ##
+  ##     # domain used in airflow emails
+  ##     AIRFLOW__WEBSERVER__BASE_URL: "http://airflow.example.com"
+  ##
+  ##     # ether environment variables
+  ##     HTTP_PROXY: "http://proxy.example.com:8080"
+  ##
+  config: {}
+
+  ## a list of users to create
+  ## - templates can ONLY be used in: `password`, `email`, `firstName`, `lastName`
+  ## - templates used a bash-like syntax: ${MY_USERNAME}, $MY_USERNAME
+  ## - templates are defined in `usersTemplates`
+  ## - `role` can be a single role or a list of roles
+  ##
+  users:
+    - username: admin
+      password: admin
+      role: Admin
+      email: admin@example.com
+      firstName: admin
+      lastName: admin
+
+  ## bash-like templates to be used in `airflow.users`
+  ## - [WARNING] if a Secret or ConfigMap is missing, the sync Pod will crash
+  ## - [WARNING] all keys must match the regex: ^[a-zA-Z_][a-zA-Z0-9_]*$
+  ##
+  ## ____ EXAMPLE _______________
+  ##   usersTemplates
+  ##     MY_USERNAME:
+  ##       kind: configmap
+  ##       name: my-configmap
+  ##       key: username
+  ##     MY_PASSWORD:
+  ##       kind: secret
+  ##       name: my-secret
+  ##       key: password
+  ##
+  usersTemplates: {}
+
+  ## if we create a Deployment to perpetually sync `airflow.users`
+  ## - when `true`, users are updated in real-time, as ConfigMaps/Secrets change
+  ## - when `true`, users changes from the WebUI will be reverted automatically
+  ## - when `false`, users will only update one-time, after each `helm upgrade`
+  ##
+  usersUpdate: true
+
+  ## a list airflow connections to create
+  ## - templates can ONLY be used in: `host`, `login`, `password`, `schema`, `extra`
+  ## - templates used a bash-like syntax: ${AWS_ACCESS_KEY} or $AWS_ACCESS_KEY
+  ## - templates are defined in `connectionsTemplates`
+  ##
+  ## ____ EXAMPLE _______________
+  ##   connections:
+  ##     - id: my_aws
+  ##       type: aws
+  ##       description: my AWS connection
+  ##       extra: |-
+  ##         { "aws_access_key_id": "${AWS_KEY_ID}",
+  ##           "aws_secret_access_key": "${AWS_ACCESS_KEY}",
+  ##           "region_name":"eu-central-1" }
+  ##
+  connections: []
+
+  ## bash-like templates to be used in `airflow.connections`
+  ## - see docs for `airflow.usersTemplates`
+  ##
+  connectionsTemplates: {}
+
+  ## if we create a Deployment to perpetually sync `airflow.connections`
+  ## - see docs for `airflow.usersUpdate`
+  ##
+  connectionsUpdate: true
+
+  ## a list airflow variables to create
+  ## - templates can ONLY be used in: `value`
+  ## - templates used a bash-like syntax: ${MY_VALUE} or $MY_VALUE
+  ## - templates are defined in `connectionsTemplates`
+  ##
+  ## ____ EXAMPLE _______________
+  ##   variables:
+  ##     - key: "var_1"
+  ##       value: "my_value_1"
+  ##     - key: "var_2"
+  ##       value: "my_value_2"
+  ##
+  variables: []
+
+  ## bash-like templates to be used in `airflow.variables`
+  ## - see docs for `airflow.usersTemplates`
+  ##
+  variablesTemplates: {}
+
+  ## if we create a Deployment to perpetually sync `airflow.variables`
+  ## - see docs for `airflow.usersUpdate`
+  ##
+  variablesUpdate: true
+
+  ## a list airflow pools to create
+  ##
+  ## ____ EXAMPLE _______________
+  ##   pools:
+  ##     - name: "pool_1"
+  ##       description: "example pool with 5 slots"
+  ##       slots: 5
+  ##     - name: "pool_2"
+  ##       description: "example pool with 2 cron policies"
+  ##       slots: 0
+  ##       ## at each sync interval, the policy with the most recently past `recurrence` is applied
+  ##       policies:
+  ##         - name: "scale up at 7pm UTC"
+  ##           slots: 50
+  ##           recurrence: "0 19 * * *"
+  ##         - name: "scale down at 6am UTC"
+  ##           slots: 10
+  ##           recurrence: "0 6 * * *"
+  ##
+  pools: []
+
+  ## if we create a Deployment to perpetually sync `airflow.pools`
+  ## - see docs for `airflow.usersUpdate`
+  ##
+  poolsUpdate: true
+
+  ## default nodeSelector for airflow Pods (is overridden by pod-specific values)
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  defaultNodeSelector: {}
+
+  ## default affinity configs for airflow Pods (is overridden by pod-specific values)
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  defaultAffinity: {}
+
+  ## default toleration configs for airflow Pods (is overridden by pod-specific values)
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  defaultTolerations: []
+
+  ## default securityContext configs for airflow Pods (is overridden by pod-specific values)
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  defaultSecurityContext:
+    ## sets the filesystem owner group of files/folders in mounted volumes
+    ## this does NOT give root permissions to Pods, only the "root" group
+    fsGroup: 0
+
+  ## extra annotations for airflow Pods
+  ##
+  podAnnotations: {}
+
+  ## extra pip packages to install in airflow Pods
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## pip packages that are protected from upgrade/downgrade by `extraPipPackages`
+  ## - [WARNING] Pods will fail to start if `extraPipPackages` would cause these packages to change versions
+  ##
+  protectedPipPackages:
+    - "apache-airflow"
+
+  ## extra environment variables for the airflow Pods
+  ## - spec for EnvVar:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envvar-v1-core
+  ##
+  extraEnv: []
+
+  ## extra containers for the airflow Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra VolumeMounts for the airflow Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the airflow Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+  ## kubernetes cluster domain name
+  ## - configured in the kubelet with `--cluster-domain` flag (deprecated):
+  ##   https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+  ## - or configured in the kubelet with configuration file `clusterDomain` option:
+  ##   https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  ##
+  clusterDomain: "cluster.local"
+
+  ########################################
+  ## FILE | airflow_local_settings.py
+  ########################################
+  ##
+  localSettings:
+    ## the full content of the `airflow_local_settings.py` file (as a string)
+    ## - docs for airflow cluster policies:
+    ##   https://airflow.apache.org/docs/apache-airflow/stable/concepts/cluster-policies.html
+    ##
+    ## ____ EXAMPLE _______________
+    ##    stringOverride: |
+    ##      # use a custom `xcom_sidecar` image for KubernetesPodOperator()
+    ##      from airflow.kubernetes.pod_generator import PodDefaults
+    ##      PodDefaults.SIDECAR_CONTAINER.image = "gcr.io/PROJECT-ID/custom-sidecar-image"
+    ##
+    stringOverride: ""
+
+    ## the name of a Secret containing a `airflow_local_settings.py` key
+    ## - if set, this disables `airflow.localSettings.stringOverride`
+    ##
+    existingSecret: ""
+
+  ########################################
+  ## FILE | pod_template.yaml
+  ########################################
+  ## - generates a file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
+  ## - the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## - the `airflow.extraPipPackages` will NOT be installed
+  ##
+  kubernetesPodTemplate:
+    ## the full content of the pod-template file (as a string)
+    ## - [WARNING] all other `kubernetesPodTemplate.*` are disabled when this is set
+    ## - docs for pod-template file:
+    ##   https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html#pod-template-file
+    ##
+    ## ____ EXAMPLE _______________
+    ##   stringOverride: |-
+    ##     apiVersion: v1
+    ##     kind: Pod
+    ##     spec: ...
+    ##
+    stringOverride: ""
+
+    ## resource requests/limits for the Pod template "base" container
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the nodeSelector configs for the Pod template
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the Pod template
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the Pod template
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## labels for the Pod template
+    ##
+    podLabels: {}
+
+    ## annotations for the Pod template
+    ##
+    podAnnotations: {}
+
+    ## the security context for the Pod template
+    ## - spec for PodSecurityContext:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+    ##
+    securityContext: {}
+
+    ## the shareProcessNamespace config for the Pod template
+    ## - docs for shareProcessNamespace:
+    ##   https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+    ##
+    shareProcessNamespace: false
+
+    ## extra pip packages to install in the Pod template
+    ##
+    ## ____ EXAMPLE _______________
+    ##   extraPipPackages:
+    ##     - "SomeProject==1.0.0"
+    ##
+    extraPipPackages: []
+
+    ## extra containers for the pod template
+    ## - spec for Container:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+    ##
+    extraContainers: []
+
+    ## extra init-containers for the Pod template
+    ## - spec of Container:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+    ##
+    extraInitContainers: []
+
+    ## extra VolumeMounts for the Pod template
+    ## - spec for VolumeMount:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+    ##
+    extraVolumeMounts: []
+
+    ## extra Volumes for the Pod template
+    ## - spec for Volume:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+    ##
+    extraVolumes: []
+
+  ########################################
+  ## COMPONENT | db-migrations Deployment
+  ########################################
+  dbMigrations:
+    ## if the db-migrations Deployment/Job is created
+    ## - [WARNING] if `false`, you have to MANUALLY run `airflow db upgrade` when required
+    ##
+    enabled: true
+
+    ## if a post-install helm Job should be used (instead of a Deployment)
+    ## - [WARNING] setting `true` will NOT work with the helm `--wait` flag,
+    ##   this is because post-install helm Jobs run AFTER the main resources become Ready,
+    ##   which will cause a deadlock, as other resources require db-migrations to become Ready
+    ##
+    runAsJob: false
+
+    ## resource requests/limits for the db-migrations Pods
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the nodeSelector configs for the db-migrations Pods
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the db-migrations Pods
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the db-migrations Pods
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## the security context for the db-migrations Pods
+    ## - spec for PodSecurityContext:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+    ##
+    securityContext: {}
+
+    ## Labels for the db-migrations Deployment
+    ##
+    labels: {}
+
+    ## Pod labels for the db-migrations Deployment
+    ##
+    podLabels: {}
+
+    ## annotations for the db-migrations Deployment/Job
+    ##
+    annotations: {}
+
+    ## Pod annotations for the db-migrations Deployment/Job
+    ##
+    podAnnotations: {}
+
+    ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+    ##
+    safeToEvict: true
+
+    ## the number of seconds between checks for unapplied db migrations
+    ## - only applies if `airflow.dbMigrations.runAsJob` is `false`
+    ##
+    checkInterval: 300
+
+  ########################################
+  ## COMPONENT | Sync Deployments
+  ########################################
+  ## - used by the Deployments/Jobs used by `airflow.{connections,pools,users,variables}`
+  ##
+  sync:
+    ## resource requests/limits for the sync Pods
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the nodeSelector configs for the sync Pods
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the sync Pods
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the sync Pods
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## the security context for the sync Pods
+    ## - spec for PodSecurityContext:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+    ##
+    securityContext: {}
+
+    ## Labels for the sync Deployments/Jobs
+    ##
+    labels: {}
+
+    ## Pod labels for the sync Deployments/Jobs
+    ##
+    podLabels: {}
+
+    ## annotations for the sync Deployments/Jobs
+    ##
+    annotations: {}
+
+    ## Pod annotations for the sync Deployments/Jobs
+    ##
+    podAnnotations: {}
+
+    ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+    ##
+    safeToEvict: true
+
+###################################
+## COMPONENT | Airflow Scheduler
+###################################
+scheduler:
+  ## the number of scheduler Pods to run
+  ## - if you set this >1 we recommend defining a `scheduler.podDisruptionBudget`
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the scheduler Pod
+  ## - spec of ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the scheduler Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the scheduler Pods
+  ## - spec of Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the scheduler Pods
+  ## - spec of Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the scheduler Pods
+  ## - spec of PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the scheduler Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the scheduler Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the scheduler Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the scheduler Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the scheduler
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the scheduler
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the scheduler
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the scheduler
+    ##
+    minAvailable: ""
+
+  ## configs for the log-cleanup sidecar of the scheduler
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ## - [WARNING] must be disabled if `logs.persistence.enabled` is `true`
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ## - spec of ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
+    ## the number of seconds between each check for files to delete
+    ##
+    intervalSeconds: 900
+
+  ## sets `airflow --num_runs` parameter used to run the airflow scheduler
+  ##
+  numRuns: -1
+
+  ## configs for the scheduler Pods' liveness probe
+  ## - "unhealthy" means the SchedulerJob has not had a heartbeat for
+  ##   AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_THRESHOLD seconds
+  ## - `periodSeconds` x `failureThreshold` = max seconds a scheduler can be in an "unhealthy" state
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 60
+    failureThreshold: 5
+
+    ## configs for an additional check that ensures tasks are being created by the scheduler
+    ## - this check works by ensuring that the most recent LocalTaskJob had a `start_date` no more than
+    ##   `taskCreationCheck.thresholdSeconds` seconds ago
+    ## - this check is useful because the scheduler can deadlock with a heartbeat, but not be scheduling new tasks:
+    ##   https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
+    ##   https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
+    ##
+    taskCreationCheck:
+      ## if the task creation check is enabled
+      ##
+      enabled: false
+
+      ## the maximum number of seconds since the start_date of the most recent LocalTaskJob
+      ## - [WARNING] must be AT LEAST equal to your shortest DAG schedule_interval
+      ## - [WARNING] DummyOperator tasks will NOT be seen by this probe
+      ##
+      thresholdSeconds: 300
+
+      ## minimum number of seconds the scheduler must have run before the task creation check begins
+      ## - [WARNING] must be long enough for the scheduler to boot and create a task
+      ##
+      schedulerAgeBeforeCheck: 180
+
+  ## extra pip packages to install in the scheduler Pods
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the scheduler Pods
+  ## - spec of VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the scheduler Pods
+  ## - spec of Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+  ## extra init containers to run in the scheduler Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
+###################################
+## COMPONENT | Airflow Webserver
+###################################
+web:
+  ########################################
+  ## FILE | webserver_config.py
+  ########################################
+  ##
+  webserverConfig:
+    ## if the `webserver_config.py` file is mounted
+    ## - set to false if you wish to mount your own `webserver_config.py` file
+    ##
+    enabled: true
+
+    ## the full content of the `webserver_config.py` file (as a string)
+    ## - docs for Flask-AppBuilder security configs:
+    ##   https://flask-appbuilder.readthedocs.io/en/latest/security.html
+    ##
+    ## ____ EXAMPLE _______________
+    ##   stringOverride: |
+    ##     from airflow import configuration as conf
+    ##     from flask_appbuilder.security.manager import AUTH_DB
+    ##
+    ##     # the SQLAlchemy connection string
+    ##     SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+    ##
+    ##     # use embedded DB for auth
+    ##     AUTH_TYPE = AUTH_DB
+    ##
+    stringOverride: ""
+
+    ## the name of a Secret containing a `webserver_config.py` key
+    ##
+    existingSecret: ""
+
+  ## the number of web Pods to run
+  ## - if you set this >1 we recommend defining a `web.podDisruptionBudget`
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the web Pod
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the web Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the web Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the web Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the web Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the web Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the web Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the web Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the web Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the web Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the web Deployment
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the web Deployment
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the web Deployment
+    ##
+    minAvailable: ""
+
+  ## configs for the Service of the web Pods
+  ##
+  service:
+    annotations: {}
+    sessionAffinity: "None"
+    sessionAffinityConfig: {}
+    type: ClusterIP
+    externalPort: 8080
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    nodePort:
+      http: ""
+
+  ## configs for the web Pods' readiness probe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  ## configs for the web Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  ## extra pip packages to install in the web Pods
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the web Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the web Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+###################################
+## COMPONENT | Airflow Workers
+###################################
+workers:
+  ## if the airflow workers StatefulSet should be deployed
+  ##
+  enabled: true
+
+  ## the number of worker Pods to run
+  ## - if you set this >1 we recommend defining a `workers.podDisruptionBudget`
+  ## - this is the minimum when `workers.autoscaling.enabled` is true
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the worker Pod
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the worker Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the worker Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the worker Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the worker Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the worker StatefulSet
+  ##
+  labels: {}
+
+  ## Pod labels for the worker StatefulSet
+  ##
+  podLabels: {}
+
+  ## annotations for the worker StatefulSet
+  ##
+  annotations: {}
+
+  ## Pod annotations for the worker StatefulSet
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the worker StatefulSet
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the worker StatefulSet
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the worker StatefulSet
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the worker StatefulSet
+    ##
+    minAvailable: ""
+
+  ## configs for the HorizontalPodAutoscaler of the worker Pods
+  ## - [WARNING] if using git-sync, ensure `dags.gitSync.resources` is set
+  ## - [WARNING] if using worker log-cleanup, ensure `workers.logCleanup.resources` is set
+  ##
+  ## ____ EXAMPLE _______________
+  ##   autoscaling:
+  ##     enabled: true
+  ##     maxReplicas: 16
+  ##     metrics:
+  ##     - type: Resource
+  ##       resource:
+  ##         name: memory
+  ##         target:
+  ##           type: Utilization
+  ##           averageUtilization: 80
+  ##
+  autoscaling:
+    enabled: false
+    maxReplicas: 2
+    metrics: []
+
+    ## the `apiVersion` to use for HorizontalPodAutoscaler resources
+    ## - for Kubernetes 1.23 and later: "autoscaling/v2"
+    ## - for Kubernetes 1.22 and before: "autoscaling/v2beta2"
+    ##
+    apiVersion: autoscaling/v2
+
+  ## configs for the celery worker Pods
+  ##
+  celery:
+    ## if celery worker Pods are gracefully terminated
+    ## - consider defining a `workers.podDisruptionBudget` to prevent there not being
+    ##   enough available workers during graceful termination waiting periods
+    ##
+    ## graceful termination process:
+    ##  1. prevent worker accepting new tasks
+    ##  2. wait AT MOST `workers.celery.gracefullTerminationPeriod` for tasks to finish
+    ##  3. send SIGTERM to worker
+    ##  4. wait AT MOST `workers.terminationPeriod` for kill to finish
+    ##  5. send SIGKILL to worker
+    ##
+    gracefullTermination: false
+
+    ## how many seconds to wait for tasks to finish before SIGTERM of the celery worker
+    ##
+    gracefullTerminationPeriod: 600
+
+  ## how many seconds to wait after SIGTERM before SIGKILL of the celery worker
+  ## - [WARNING] tasks that are still running during SIGKILL will be orphaned, this is important
+  ##   to understand with KubernetesPodOperator(), as Pods may continue running
+  ##
+  terminationPeriod: 60
+
+  ## configs for the log-cleanup sidecar of the worker Pods
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ## - [WARNING] must be disabled if `logs.persistence.enabled` is `true`
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ## - spec of ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
+    ## the number of seconds between each check for files to delete
+    ##
+    intervalSeconds: 900
+
+  ## extra pip packages to install in the worker Pod
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the worker Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the worker Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+###################################
+## COMPONENT | Triggerer
+###################################
+triggerer:
+  ## if the airflow triggerer should be deployed
+  ## - [WARNING] the triggerer component was added in airflow 2.2.0
+  ## - [WARNING] if `airflow.legacyCommands` is `true` the triggerer will NOT be deployed
+  ##
+  enabled: true
+
+  ## the number of triggerer Pods to run
+  ## - if you set this >1 we recommend defining a `triggerer.podDisruptionBudget`
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the triggerer Pods
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the triggerer Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the triggerer Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the triggerer Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the triggerer Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the triggerer Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the triggerer Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the triggerer Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the triggerer Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the triggerer Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the triggerer Deployment
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the triggerer Deployment
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the triggerer Deployment
+    ##
+    minAvailable: ""
+
+  ## maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`)
+  ##
+  capacity: 1000
+
+  ## configs for the triggerer Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 60
+    failureThreshold: 5
+
+  ## extra pip packages to install in the triggerer Pod
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the triggerer Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the triggerer Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+###################################
+## COMPONENT | Flower
+###################################
+flower:
+  ## if the airflow flower UI should be deployed
+  ##
+  enabled: true
+
+  ## the number of flower Pods to run
+  ## - if you set this >1 we recommend defining a `flower.podDisruptionBudget`
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the flower Pod
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the flower Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the flower Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the flower Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the flower Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the flower Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the flower Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the flower Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the flower Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the flower Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the flower Deployment
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the flower Deployment
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the flower Deployment
+    ##
+    minAvailable: ""
+
+  ## the name of a pre-created secret containing the basic authentication value for flower
+  ## - this will override any value of `config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH`
+  ##
+  basicAuthSecret: ""
+
+  ## the key within `flower.basicAuthSecret` containing the basic authentication string
+  ##
+  basicAuthSecretKey: ""
+
+  ## configs for the Service of the flower Pods
+  ##
+  service:
+    annotations: {}
+    type: ClusterIP
+    externalPort: 5555
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    nodePort:
+      http:
+
+  ## configs for the flower Pods' readinessProbe probe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  ## configs for the flower Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  ## extra pip packages to install in the flower Pod
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the flower Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the flower Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+###################################
+## CONFIG | Airflow Logs
+###################################
+logs:
+  ## the airflow logs folder
+  ##
+  path: /opt/airflow/logs
+
+  ## configs for the logs PVC
+  ##
+  persistence:
+    ## if a persistent volume is mounted at `logs.path`
+    ##
+    enabled: false
+
+    ## the name of an existing PVC to use
+    ##
+    existingClaim: ""
+
+    ## sub-path under `logs.persistence.existingClaim` to use
+    ##
+    subPath: ""
+
+    ## the name of the StorageClass used by the PVC
+    ## - if set to "", then `PersistentVolumeClaim/spec.storageClassName` is omitted
+    ## - if set to "-", then `PersistentVolumeClaim/spec.storageClassName` is set to ""
+    ##
+    storageClass: ""
+
+    ## the access mode of the PVC
+    ## - [WARNING] must be "ReadWriteMany" or airflow pods will fail to start
+    ##
+    accessMode: ReadWriteMany
+
+    ## the size of PVC to request
+    ##
+    size: 1Gi
+
+###################################
+## CONFIG | Airflow DAGs
+###################################
+dags:
+  ## the airflow dags folder
+  ##
+  path: /opt/airflow/dags
+
+  ## configs for the dags PVC
+  ##
+  persistence:
+    ## if a persistent volume is mounted at `dags.path`
+    ##
+    enabled: false
+
+    ## the name of an existing PVC to use
+    ##
+    existingClaim: ""
+
+    ## sub-path under `dags.persistence.existingClaim` to use
+    ##
+    subPath: ""
+
+    ## the name of the StorageClass used by the PVC
+    ## - if set to "", then `PersistentVolumeClaim/spec.storageClassName` is omitted
+    ## - if set to "-", then `PersistentVolumeClaim/spec.storageClassName` is set to ""
+    ##
+    storageClass: ""
+
+    ## the access mode of the PVC
+    ## - [WARNING] must be "ReadOnlyMany" or "ReadWriteMany" otherwise airflow pods will fail to start
+    ##
+    accessMode: ReadOnlyMany
+
+    ## the size of PVC to request
+    ##
+    size: 1Gi
+
+  ## configs for the git-sync sidecar (https://github.com/kubernetes/git-sync)
+  ##
+  gitSync:
+    ## if the git-sync sidecar container is enabled
+    ##
+    enabled: false
+
+    ## the git-sync container image
+    ##
+    image:
+      repository: registry.k8s.io/git-sync/git-sync
+      tag: v3.6.5
+      pullPolicy: IfNotPresent
+      uid: 65533
+      gid: 65533
+
+    ## resource requests/limits for the git-sync container
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the url of the git repo
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # https git repo
+    ##   repo: "https://github.com/USERNAME/REPOSITORY.git"
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # ssh git repo
+    ##   repo: "git@github.com:USERNAME/REPOSITORY.git"
+    ##
+    repo: ""
+
+    ## the sub-path within your repo where dags are located
+    ## - only dags under this path within your repo will be seen by airflow,
+    ##   (note, the full repo will still be cloned)
+    ##
+    repoSubPath: ""
+
+    ## the git branch to check out
+    ##
+    branch: master
+
+    ## the git revision (tag or hash) to check out
+    ##
+    revision: HEAD
+
+    ## shallow clone with a history truncated to the specified number of commits
+    ##
+    depth: 1
+
+    ## the number of seconds between syncs
+    ##
+    syncWait: 60
+
+    ## the max number of seconds allowed for a complete sync
+    ##
+    syncTimeout: 120
+
+    ## the git submodule behavior
+    ## - allowed values: "recursive", "shallow", "off"
+    ##
+    submodules: recursive
+
+    ## the name of a pre-created Secret with git http credentials
+    ##
+    httpSecret: ""
+
+    ## the key in `dags.gitSync.httpSecret` with your git username
+    ##
+    httpSecretUsernameKey: username
+
+    ## the key in `dags.gitSync.httpSecret` with your git password/token
+    ##
+    httpSecretPasswordKey: password
+
+    ## the name of a pre-created Secret with git ssh credentials
+    ##
+    sshSecret: ""
+
+    ## the key in `dags.gitSync.sshSecret` with your ssh-key file
+    ##
+    sshSecretKey: id_rsa
+
+    ## the string value of a "known_hosts" file (for SSH only)
+    ## - [WARNING] known_hosts verification will be disabled if left empty, making you more
+    ##   vulnerable to repo spoofing attacks
+    ##
+    ## ____ EXAMPLE _______________
+    ##   sshKnownHosts: |-
+    ##     <HOST_NAME> ssh-rsa <HOST_KEY>
+    ##
+    sshKnownHosts: ""
+
+    ## the number of consecutive failures allowed before aborting
+    ##  - the first sync must succeed
+    ##  - a value of -1 will retry forever after the initial sync
+    ##
+    maxFailures: 0
+
+###################################
+## CONFIG | Kubernetes Ingress
+###################################
+ingress:
+  ## if we should deploy Ingress resources
+  ##
+  enabled: false
+
+  ## the `apiVersion` to use for Ingress resources
+  ## - for Kubernetes 1.19 and later: "networking.k8s.io/v1"
+  ## - for Kubernetes 1.18 and before: "networking.k8s.io/v1beta1"
+  ##
+  apiVersion: networking.k8s.io/v1
+
+  ## configs for the Ingress of the web Service
+  ##
+  web:
+    ## annotations for the web Ingress
+    ##
+    annotations: {}
+
+    ## additional labels for the web Ingress
+    ##
+    labels: {}
+
+    ## the path for the web Ingress
+    ## - [WARNING] do NOT include the trailing slash (for root, set an empty string)
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # webserver URL: http://example.com/airflow
+    ##   path: "/airflow"
+    ##
+    path: ""
+
+    ## the hostname for the web Ingress
+    ##
+    host: ""
+
+    ## the Ingress Class for the web Ingress
+    ## - [WARNING] requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ##
+    ingressClassName: ""
+
+    ## configs for web Ingress TLS
+    ##
+    tls:
+      ## enable TLS termination for the web Ingress
+      ##
+      enabled: false
+
+      ## the name of a pre-created Secret containing a TLS private key and certificate
+      ##
+      secretName: ""
+
+    ## http paths to add to the web Ingress before the default path
+    ##
+    ## ____ EXAMPLE _______________
+    ##   precedingPaths:
+    ##     - path: "/*"
+    ##       serviceName: "my-service"
+    ##       servicePort: "port-name"
+    ##
+    precedingPaths: []
+
+    ## http paths to add to the web Ingress after the default path
+    ##
+    ## ____ EXAMPLE _______________
+    ##   succeedingPaths:
+    ##     - path: "/extra-service"
+    ##       serviceName: "my-service"
+    ##       servicePort: "port-name"
+    ##
+    succeedingPaths: []
+
+  ## configs for the Ingress of the flower Service
+  ##
+  flower:
+    ## annotations for the flower Ingress
+    ##
+    annotations: {}
+
+    ## additional labels for the flower Ingress
+    ##
+    labels: {}
+
+    ## the path for the flower Ingress
+    ## - [WARNING] do NOT include the trailing slash (for root, set an empty string)
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # flower URL: http://example.com/airflow/flower
+    ##   path: "/airflow/flower"
+    ##
+    path: ""
+
+    ## the hostname for the flower Ingress
+    ##
+    host: ""
+
+    ## the Ingress Class for the flower Ingress
+    ## - [WARNING] requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ##
+    ingressClassName: ""
+
+    ## configs for flower Ingress TLS
+    ##
+    tls:
+      ## enable TLS termination for the flower Ingress
+      ##
+      enabled: false
+
+      ## the name of a pre-created Secret containing a TLS private key and certificate
+      ##
+      secretName: ""
+
+    ## http paths to add to the flower Ingress before the default path
+    ##
+    ## ____ EXAMPLE _______________
+    ##   precedingPaths:
+    ##     - path: "/*"
+    ##       serviceName: "my-service"
+    ##       servicePort: "port-name"
+    ##
+    precedingPaths: []
+
+    ## http paths to add to the flower Ingress after the default path
+    ##
+    ## ____ EXAMPLE _______________
+    ##   succeedingPaths:
+    ##     - path: "/extra-service"
+    ##       serviceName: "my-service"
+    ##       servicePort: "port-name"
+    ##
+    succeedingPaths: []
+
+###################################
+## CONFIG | Kubernetes RBAC
+###################################
+rbac:
+  ## if Kubernetes RBAC resources are created
+  ## - these allow the service account to create/delete Pods in the airflow namespace,
+  ##   which is required for the KubernetesPodOperator() to function
+  ##
+  create: true
+
+  ## if the created RBAC Role has GET/LIST on Event resources
+  ## - this is needed for KubernetesPodOperator() to use `log_events_on_failure=True`
+  ##
+  events: true
+
+###################################
+## CONFIG | Kubernetes ServiceAccount
+###################################
+serviceAccount:
+  ## if a Kubernetes ServiceAccount is created
+  ## - if `false`, you must create the service account outside this chart with name: `serviceAccount.name`
+  ##
+  create: true
+
+  ## the name of the ServiceAccount
+  ## - by default the name is generated using the `airflow.serviceAccountName` template in `_helpers/common.tpl`
+  ##
+  name: ""
+
+  ## annotations for the ServiceAccount
+  ##
+  ## ____ EXAMPLE _______________
+  ##   # EKS - IAM Roles for Service Accounts
+  ##   annotations:
+  ##     eks.amazonaws.com/role-arn: "arn:aws:iam::XXXXXXXXXX:role/<<MY-ROLE-NAME>>"
+  ##
+  ## ____ EXAMPLE _______________
+  ##   # GKE - WorkloadIdentity
+  ##   annotations:
+  ##     iam.gke.io/gcp-service-account: "<<GCP_SERVICE>>@<<GCP_PROJECT>>.iam.gserviceaccount.com"
+  ##
+  annotations: {}
+
+###################################
+## CONFIG | Kubernetes Extra Manifests
+###################################
+## a list of extra Kubernetes manifests that will be deployed alongside the chart
+## - helm templates within these strings will be rendered
+##
+## ____ EXAMPLE _______________
+##   extraManifests:
+##     - |
+##       apiVersion: v1
+##       kind: Secret
+##       metadata:
+##         name: airflow-postgres
+##       data:
+##         postgresql-password: {{ `password1` | b64enc | quote }}
+##     - |
+##       apiVersion: apps/v1
+##       kind: Deployment
+##       metadata:
+##         name: {{ include "airflow.fullname" . }}-busybox
+##         labels:
+##           app: {{ include "airflow.labels.app" . }}
+##           component: busybox
+##           chart: {{ include "airflow.labels.chart" . }}
+##           release: {{ .Release.Name }}
+##           heritage: {{ .Release.Service }}
+##       spec:
+##         replicas: 1
+##         selector:
+##           matchLabels:
+##             app: {{ include "airflow.labels.app" . }}
+##             component: busybox
+##             release: {{ .Release.Name }}
+##         template:
+##           metadata:
+##             labels:
+##               app: {{ include "airflow.labels.app" . }}
+##               component: busybox
+##               release: {{ .Release.Name }}
+##           spec:
+##             containers:
+##               - name: busybox
+##                 image: busybox:1.35
+##                 command:
+##                   - "/bin/sh"
+##                   - "-c"
+##                 args:
+##                   - |
+##                     ## to break the infinite loop when we receive SIGTERM
+##                     trap "exit 0" SIGTERM;
+##                     ## keep the container running (so people can `kubectl exec -it` into it)
+##                     while true; do
+##                       echo "I am alive...";
+##                       sleep 30;
+##                     done
+##
+extraManifests: []
+
+###################################
+## DATABASE | PgBouncer
+###################################
+pgbouncer:
+  ## if the pgbouncer Deployment is created
+  ##
+  enabled: true
+
+  ## configs for the pgbouncer container image
+  ##
+  image:
+    repository: ghcr.io/airflow-helm/pgbouncer
+    tag: 1.18.0-patch.1
+    pullPolicy: IfNotPresent
+    uid: 1001
+    gid: 1001
+
+  ## resource requests/limits for the pgbouncer Pods
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the pgbouncer Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the pgbouncer Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the pgbouncer Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the pgbouncer Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## Labels for the pgbouncer Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the pgbouncer Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the pgbouncer Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the pgbouncer Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the pgbouncer Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the pgbouncer Deployment
+    ##
+    enabled: false
+
+    ## the `apiVersion` to use for PodDisruptionBudget resources
+    ## - for Kubernetes 1.21 and later: "policy/v1"
+    ## - for Kubernetes 1.20 and before: "policy/v1beta1"
+    ##
+    apiVersion: policy/v1
+
+    ## the maximum unavailable pods/percentage for the pgbouncer Deployment
+    ##
+    maxUnavailable:
+
+    ## the minimum available pods/percentage for the pgbouncer Deployment
+    ##
+    minAvailable:
+
+  ## configs for the pgbouncer Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 60
+    failureThreshold: 3
+
+  ## configs for the pgbouncer Pods' startup probe
+  ##
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 30
+
+  ## the maximum number of seconds to wait for queries upon pod termination, before force killing
+  ##
+  terminationGracePeriodSeconds: 120
+
+  ## sets pgbouncer config: `auth_type`
+  ##
+  authType: md5
+
+  ## sets pgbouncer config: `max_client_conn`
+  ##
+  maxClientConnections: 1000
+
+  ## sets pgbouncer config: `default_pool_size`
+  ##
+  poolSize: 20
+
+  ## sets pgbouncer config: `log_disconnections`
+  ##
+  logDisconnections: 0
+
+  ## sets pgbouncer config: `log_connections`
+  ##
+  logConnections: 0
+
+  ## ssl configs for: clients -> pgbouncer
+  ##
+  clientSSL:
+    ## sets pgbouncer config: `client_tls_sslmode`
+    ##
+    mode: prefer
+
+    ## sets pgbouncer config: `client_tls_ciphers`
+    ##
+    ciphers: normal
+
+    ## sets pgbouncer config: `client_tls_ca_file`
+    ##
+    caFile:
+      existingSecret: ""
+      existingSecretKey: root.crt
+
+    ## sets pgbouncer config: `client_tls_key_file`
+    ## - [WARNING] a self-signed cert & key are generated if left empty
+    ##
+    keyFile:
+      existingSecret: ""
+      existingSecretKey: client.key
+
+    ## sets pgbouncer config: `client_tls_cert_file`
+    ## - [WARNING] a self-signed cert & key are generated if left empty
+    ##
+    certFile:
+      existingSecret: ""
+      existingSecretKey: client.crt
+
+  ## ssl configs for: pgbouncer -> postgres
+  ##
+  serverSSL:
+    ## sets pgbouncer config: `server_tls_sslmode`
+    ##
+    mode: prefer
+
+    ## sets pgbouncer config: `server_tls_ciphers`
+    ##
+    ciphers: normal
+
+    ## sets pgbouncer config: `server_tls_ca_file`
+    ##
+    caFile:
+      existingSecret: ""
+      existingSecretKey: root.crt
+
+    ## sets pgbouncer config: `server_tls_key_file`
+    ##
+    keyFile:
+      existingSecret: ""
+      existingSecretKey: server.key
+
+    ## sets pgbouncer config: `server_tls_cert_file`
+    ##
+    certFile:
+      existingSecret: ""
+      existingSecretKey: server.crt
+
+###################################
+## DATABASE | Embedded Postgres
+###################################
+postgresql:
+  ## if the `stable/postgresql` chart is used
+  ## - [WARNING] the embedded Postgres is NOT SUITABLE for production deployments of Airflow
+  ## - [WARNING] consider using an external database with `externalDatabase.*`
+  ## - set to `false` if using `externalDatabase.*`
+  ##
+  enabled: true
+
+  ## configs for the postgres container image
+  ##
+  image:
+    registry: ghcr.io
+    repository: airflow-helm/postgresql-bitnami
+    tag: 11.16-patch.0
+    pullPolicy: IfNotPresent
+
+  ## the postgres database to use
+  ##
+  postgresqlDatabase: airflow
+
+  ## the postgres user to create
+  ##
+  postgresqlUsername: postgres
+
+  ## the postgres user's password
+  ##
+  postgresqlPassword: airflow
+
+  ## the name of a pre-created secret containing the postgres password
+  ##
+  existingSecret: ""
+
+  ## the key within `postgresql.existingSecret` containing the password string
+  ##
+  existingSecretKey: "postgresql-password"
+
+  ## configs for the PVC of postgresql
+  ##
+  persistence:
+    ## if postgres will use Persistent Volume Claims to store data
+    ## - [WARNING] if false, data will be LOST as postgres Pods restart
+    ##
+    enabled: true
+
+    ## the name of the StorageClass used by the PVC
+    ##
+    storageClass: ""
+
+    ## the access modes of the PVC
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## the size of PVC to request
+    ##
+    size: 8Gi
+
+  ## configs for the postgres StatefulSet
+  ##
+  master:
+    ## the nodeSelector configs for the postgres Pods
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the postgres Pods
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the postgres Pods
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## annotations for the postgres Pods
+    ##
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+
+###################################
+## DATABASE | External Database
+###################################
+externalDatabase:
+  ## the type of external database
+  ## - allowed values: "mysql", "postgres"
+  ##
+  type: postgres
+
+  ## the host of the external database
+  ##
+  host: localhost
+
+  ## the port of the external database
+  ##
+  port: 5432
+
+  ## the database/scheme to use within the external database
+  ##
+  database: airflow
+
+  ## the username for the external database
+  ##
+  user: airflow
+
+  ## the name of a pre-created secret containing the external database user
+  ## - if set, this overrides `externalDatabase.user`
+  ##
+  userSecret: ""
+
+  ## the key within `externalDatabase.userSecret` containing the user string
+  ##
+  userSecretKey: "postgresql-user"
+
+  ## the password for the external database
+  ## - [WARNING] to avoid storing the password in plain-text within your values,
+  ##   create a Kubernetes secret and use `externalDatabase.passwordSecret`
+  ##
+  password: ""
+
+  ## the name of a pre-created secret containing the external database password
+  ## - if set, this overrides `externalDatabase.password`
+  ##
+  passwordSecret: ""
+
+  ## the key within `externalDatabase.passwordSecret` containing the password string
+  ##
+  passwordSecretKey: "postgresql-password"
+
+  ## extra connection-string properties for the external database
+  ##
+  ## ____ EXAMPLE _______________
+  ##   # require SSL (only for Postgres)
+  ##   properties: "?sslmode=require"
+  ##
+  properties: ""
+
+###################################
+## DATABASE | Embedded Redis
+###################################
+redis:
+  ## if the `stable/redis` chart is used
+  ## - set to `false` if `airflow.executor` is `KubernetesExecutor`
+  ## - set to `false` if using `externalRedis.*`
+  ##
+  enabled: true
+
+  ## configs for the redis container image
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/redis
+    tag: 5.0.14-debian-10-r173
+    pullPolicy: IfNotPresent
+
+  ## the redis password
+  ##
+  password: airflow
+
+  ## the name of a pre-created secret containing the redis password
+  ##
+  existingSecret: ""
+
+  ## the key within `redis.existingSecret` containing the password string
+  ##
+  existingSecretPasswordKey: "redis-password"
+
+  ## configs for redis cluster mode
+  ##
+  cluster:
+    ## if redis runs in cluster mode
+    ##
+    enabled: false
+
+    ## the number of redis slaves
+    ##
+    slaveCount: 1
+
+  ## configs for the redis master StatefulSet
+  ##
+  master:
+    ## resource requests/limits for the redis master Pods
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the nodeSelector configs for the redis master Pods
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the redis master Pods
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the redis master Pods
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## annotations for the redis master Pods
+    ##
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+
+    ## configs for the PVC of the redis master Pods
+    ##
+    persistence:
+      ## use a PVC to persist data
+      ##
+      enabled: false
+
+      ## the name of the StorageClass used by the PVC
+      ##
+      storageClass: ""
+
+      ## the access mode of the PVC
+      ##
+      accessModes:
+      - ReadWriteOnce
+
+      ## the size of PVC to request
+      ##
+      size: 8Gi
+
+  ## configs for the redis slave StatefulSet
+  ## - only used if `redis.cluster.enabled` is `true`
+  ##
+  slave:
+    ## resource requests/limits for the slave Pods
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the nodeSelector configs for the redis slave Pods
+    ## - docs for nodeSelector:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    ##
+    nodeSelector: {}
+
+    ## the affinity configs for the redis slave Pods
+    ## - spec for Affinity:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+    ##
+    affinity: {}
+
+    ## the toleration configs for the redis slave Pods
+    ## - spec for Toleration:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+    ##
+    tolerations: []
+
+    ## annotations for the slave Pods
+    ##
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+
+    ## configs for the PVC of the redis slave Pods
+    ##
+    persistence:
+      ## use a PVC to persist data
+      ##
+      enabled: false
+
+      ## the name of the StorageClass used by the PVC
+      ##
+      storageClass: ""
+
+      ## the access mode of the PVC
+      ##
+      accessModes:
+        - ReadWriteOnce
+
+      ## the size of PVC to request
+      ##
+      size: 8Gi
+
+###################################
+## DATABASE | External Redis
+###################################
+externalRedis:
+  ## the host of the external redis
+  ##
+  host: localhost
+
+  ## the port of the external redis
+  ##
+  port: 6379
+
+  ## the database number to use within the external redis
+  ##
+  databaseNumber: 1
+
+  ## the password for the external redis
+  ## - [WARNING] to avoid storing the password in plain-text within your values,
+  ##   create a Kubernetes secret and use `externalRedis.passwordSecret`
+  ##
+  password: ""
+
+  ## the name of a pre-created secret containing the external redis password
+  ## - if set, this overrides `externalRedis.password`
+  ##
+  passwordSecret: ""
+
+  ## the key within `externalRedis.passwordSecret` containing the password string
+  ##
+  passwordSecretKey: "redis-password"
+
+  ## extra connection-string properties for the external redis
+  ##
+  ## ____ EXAMPLE _______________
+  ##   properties: "?ssl_cert_reqs=CERT_OPTIONAL"
+  ##
+  properties: ""
+
+###################################
+## CONFIG | ServiceMonitor (Prometheus Operator)
+###################################
+serviceMonitor:
+  ## if ServiceMonitor resources should be deployed for airflow webserver
+  ## - [WARNING] you will need a metrics exporter in your `airflow.image`, for example:
+  ##   https://github.com/epoch8/airflow-exporter
+  ## - ServiceMonitor is a resource from prometheus-operator:
+  ##   https://github.com/prometheus-operator/prometheus-operator
+  ##
+  enabled: false
+
+  ## labels for ServiceMonitor, so that Prometheus can select it
+  ##
+  selector:
+    prometheus: kube-prometheus
+
+  ## the ServiceMonitor web endpoint path
+  ##
+  path: /admin/metrics
+
+  ## the ServiceMonitor web endpoint interval
+  ##
+  interval: "30s"
+
+###################################
+## CONFIG | PrometheusRule (Prometheus Operator)
+###################################
+prometheusRule:
+  ## if PrometheusRule resources should be deployed for airflow webserver
+  ## - [WARNING] you will need a metrics exporter in your `airflow.image`, for example:
+  ##   https://github.com/epoch8/airflow-exporter
+  ## - PrometheusRule is a resource from prometheus-operator:
+  ##   https://github.com/prometheus-operator/prometheus-operator
+  ##
+  enabled: false
+
+  ## labels for PrometheusRule, so that Prometheus can select it
+  ##
+  additionalLabels: {}
+
+  ## alerting rules for Prometheus
+  ## - docs for alerting rules: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+  ##
+  groups: []

--- a/deployment/plat-infra-services/airflow/community/helm-values.yaml
+++ b/deployment/plat-infra-services/airflow/community/helm-values.yaml
@@ -1,0 +1,305 @@
+########################################
+## CONFIG | Airflow Configs
+########################################
+airflow:
+  ## if we use legacy 1.10 airflow commands
+  legacyCommands: false
+
+  ## configs for the airflow container image
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/configuration/airflow-version.md
+  image:
+    repository: apache/airflow
+    tag: 2.5.3-python3.8
+
+  ## the airflow executor type to use
+  executor: KubernetesExecutor
+
+  ## the fernet encryption key (sets `AIRFLOW__CORE__FERNET_KEY`)
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/security/set-fernet-key.md
+  ## [WARNING] change from default value to ensure security
+  fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
+
+  ## the secret_key for flask (sets `AIRFLOW__WEBSERVER__SECRET_KEY`)
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/security/set-webserver-secret-key.md
+  ## [WARNING] change from default value to ensure security
+  webserverSecretKey: "THIS IS UNSAFE!"
+
+  ## environment variables for airflow configs
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/configuration/airflow-configs.md
+  config:
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "False"
+    AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+
+  ## a list of users to create
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/security/airflow-users.md
+  users:
+    - username: admin
+      password: admin
+      role: Admin
+      email: admin@example.com
+      firstName: admin
+      lastName: admin
+
+  ## a list airflow connections to create
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/airflow-connections.md
+  connections: []
+
+  ## a list airflow variables to create
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/airflow-variables.md
+  variables: []
+
+  ## a list airflow pools to create
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/airflow-pools.md
+  pools: []
+
+  ## extra pip packages to install in airflow Pods
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/configuration/extra-python-packages.md
+  ## [WARNING] this feature is not recommended for production use, see docs
+  extraPipPackages: []
+
+  ## extra environment variables for the airflow Pods
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-environment-variables.md
+  extraEnv: []
+
+  ## extra VolumeMounts for the airflow Pods
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-files.md
+  extraVolumeMounts: []
+
+  ## extra Volumes for the airflow Pods
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-files.md
+  extraVolumes: []
+
+  ## configs generating the `pod_template.yaml` file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
+  ## [NOTE] the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## [NOTE] the `airflow.extraPipPackages` will NOT be installed
+  kubernetesPodTemplate:
+
+    ## the full content of the pod-template file (as a string)
+    ## [NOTE] all other `kubernetesPodTemplate.*` are disabled when this is set
+    stringOverride: ""
+
+    ## resource requests/limits for the Pod template "base" container
+    ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    resources: {}
+
+    ## extra pip packages to install in the Pod template
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/configuration/extra-python-packages.md
+    ## [WARNING] this feature is not recommended for production use, see docs
+    extraPipPackages: []
+
+    ## extra VolumeMounts for the Pod template
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-files.md
+    extraVolumeMounts: []
+
+    ## extra Volumes for the Pod template
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/mount-files.md
+    extraVolumes: []
+
+###################################
+## COMPONENT | Airflow Scheduler
+###################################
+scheduler:
+  ## the number of scheduler Pods to run
+  replicas: 1
+
+  ## resource requests/limits for the scheduler Pods
+  ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  resources: {}
+
+  ## configs for the log-cleanup sidecar of the scheduler
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/log-cleanup.md
+  logCleanup:
+    enabled: true
+    retentionMinutes: 21600
+
+  ## configs for the scheduler Pods' liveness probe
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
+  livenessProbe:
+    enabled: true
+
+    ## configs for an additional check that ensures tasks are being created by the scheduler
+    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
+    taskCreationCheck:
+      enabled: false
+      thresholdSeconds: 300
+      schedulerAgeBeforeCheck: 180
+
+###################################
+## COMPONENT | Airflow Webserver
+###################################
+web:
+  ## the number of web Pods to run
+  replicas: 1
+
+  ## resource requests/limits for the web Pods
+  ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  resources: {}
+
+  ## configs for the Service of the web Pods
+  service:
+    type: ClusterIP
+    externalPort: 8080
+
+  ## configs generating the `webserver_config.py` file
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/configuration/airflow-configs.md#webserver_configpy
+  webserverConfig:
+    ## the full content of the `webserver_config.py` file (as a string)
+    stringOverride: |
+      from airflow import configuration as conf
+      from flask_appbuilder.security.manager import AUTH_DB
+
+      # the SQLAlchemy connection string
+      SQLALCHEMY_DATABASE_URI = conf.get("core", "SQL_ALCHEMY_CONN")
+
+      # use embedded DB for auth
+      AUTH_TYPE = AUTH_DB
+
+    ## the name of a Secret containing a `webserver_config.py` key
+    existingSecret: ""
+
+###################################
+## COMPONENT | Airflow Workers
+###################################
+workers:
+  ## if the airflow workers StatefulSet should be deployed
+  enabled: false
+
+###################################
+## COMPONENT | Triggerer
+###################################
+triggerer:
+  ## if the airflow triggerer should be deployed
+  enabled: true
+
+  ## the number of triggerer Pods to run
+  replicas: 1
+
+  ## resource requests/limits for the triggerer Pods
+  ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  resources: {}
+
+  ## maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`)
+  capacity: 1000
+
+###################################
+## COMPONENT | Flower
+###################################
+flower:
+  ## if the airflow flower UI should be deployed
+  enabled: false
+
+###################################
+## CONFIG | Airflow Logs
+###################################
+logs:
+  ## the airflow logs folder
+  path: /opt/airflow/logs
+
+  ## configs for the logs PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/log-persistence.md
+  persistence:
+    enabled: false
+
+###################################
+## CONFIG | Airflow DAGs
+###################################
+dags:
+  ## the airflow dags folder
+  path: /opt/airflow/dags
+
+  ## configs for the dags PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  gitSync:
+    enabled: false
+
+###################################
+## CONFIG | Kubernetes Ingress
+###################################
+ingress:
+  ## if we should deploy Ingress resources
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/ingress.md
+  enabled: false
+
+###################################
+## CONFIG | Kubernetes ServiceAccount
+###################################
+serviceAccount:
+  ## if a Kubernetes ServiceAccount is created
+  create: true
+
+  ## the name of the ServiceAccount
+  name: ""
+
+  ## annotations for the ServiceAccount
+  annotations: {}
+
+###################################
+## CONFIG | Kubernetes Extra Manifests
+###################################
+
+## a list of extra Kubernetes manifests that will be deployed alongside the chart
+## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/kubernetes/extra-manifests.md
+extraManifests: []
+
+###################################
+## DATABASE | PgBouncer
+###################################
+pgbouncer:
+  ## if the pgbouncer Deployment is created
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/database/pgbouncer.md
+  enabled: true
+
+  ## resource requests/limits for the pgbouncer Pods
+  ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  resources: {}
+
+  ## sets pgbouncer config: `auth_type`
+  authType: md5
+
+###################################
+## DATABASE | Embedded Postgres
+###################################
+postgresql:
+  ## if the `stable/postgresql` chart is used
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/database/embedded-database.md
+  ## [WARNING] the embedded Postgres is NOT SUITABLE for production deployments of Airflow
+  ## [WARNING] consider using an external database with `externalDatabase.*`
+  enabled: true
+
+  ## configs for the PVC of postgresql
+  persistence:
+    enabled: true
+    storageClass: "directpv-min-io"
+    size: 1Gi
+
+###################################
+## DATABASE | External Database
+###################################
+externalDatabase:
+  ## the type of external database
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/database/external-database.md
+  type: postgres
+
+###################################
+## DATABASE | Embedded Redis
+###################################
+redis:
+  ## if the `stable/redis` chart is used
+  enabled: false
+
+###################################
+## DATABASE | External Redis
+###################################
+externalRedis:
+  ## the host of the external redis
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/database/external-redis.md
+  host: localhost

--- a/deployment/plat-infra-services/airflow/community/namespace.yaml
+++ b/deployment/plat-infra-services/airflow/community/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airflow

--- a/deployment/plat-infra-services/airflow/community/out.yaml
+++ b/deployment/plat-infra-services/airflow/community/out.yaml
@@ -1,0 +1,1544 @@
+---
+# Source: airflow/templates/rbac/airflow-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+---
+# Source: airflow/charts/postgresql/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-postgresql
+  labels:
+    app: postgresql
+    chart: postgresql-8.6.4
+    release: "airflow"
+    heritage: "Helm"
+type: Opaque
+data:
+  postgresql-password: "YWlyZmxvdw=="
+---
+# Source: airflow/templates/config/secret-config-envs.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-config-envs
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+## we must use `data` rather than `stringData` (see: https://github.com/helm/helm/issues/10010)
+data:
+  ## ================
+  ## Linux Configs
+  ## ================
+  TZ: "RXRjL1VUQw=="
+
+  ## ================
+  ## Database Configs
+  ## ================
+  ## database host/port
+  DATABASE_HOST: "YWlyZmxvdy1wZ2JvdW5jZXIuYWlyZmxvdy5zdmMuY2x1c3Rlci5sb2NhbA=="
+  DATABASE_PORT: "NjQzMg=="
+
+  ## database configs
+  DATABASE_DB: "YWlyZmxvdw=="
+
+  ## bash command which echos the URL encoded value of $DATABASE_USER
+  DATABASE_USER_CMD: "ZWNobyAiJHtEQVRBQkFTRV9VU0VSfSIgfCBweXRob24zIC1jICJpbXBvcnQgdXJsbGliLnBhcnNlOyBlbmNvZGVkX3VzZXIgPSB1cmxsaWIucGFyc2UucXVvdGUoaW5wdXQoKSk7IHByaW50KGVuY29kZWRfdXNlciki"
+
+  ## bash command which echos the URL encoded value of $DATABASE_PASSWORD
+  DATABASE_PASSWORD_CMD: "ZWNobyAiJHtEQVRBQkFTRV9QQVNTV09SRH0iIHwgcHl0aG9uMyAtYyAiaW1wb3J0IHVybGxpYi5wYXJzZTsgZW5jb2RlZF9wYXNzID0gdXJsbGliLnBhcnNlLnF1b3RlKGlucHV0KCkpOyBwcmludChlbmNvZGVkX3Bhc3MpIg=="
+
+  ## bash command which echos the DB connection string in SQLAlchemy format
+  DATABASE_SQLALCHEMY_CMD: "ZWNobyAtbiAicG9zdGdyZXNxbCtwc3ljb3BnMjovLyQoZXZhbCAkREFUQUJBU0VfVVNFUl9DTUQpOiQoZXZhbCAkREFUQUJBU0VfUEFTU1dPUkRfQ01EKUAke0RBVEFCQVNFX0hPU1R9OiR7REFUQUJBU0VfUE9SVH0vJHtEQVRBQkFTRV9EQn0i"
+
+  ## bash command which echos the DB connection string in Celery result_backend format
+  DATABASE_CELERY_CMD: "ZWNobyAtbiAiZGIrcG9zdGdyZXNxbDovLyQoZXZhbCAkREFUQUJBU0VfVVNFUl9DTUQpOiQoZXZhbCAkREFUQUJBU0VfUEFTU1dPUkRfQ01EKUAke0RBVEFCQVNFX0hPU1R9OiR7REFUQUJBU0VfUE9SVH0vJHtEQVRBQkFTRV9EQn0i"
+  ## bash command which echos the DB connection string in `psql` cli format
+  ## NOTE: uses `127.0.0.1` as the host because this is only used in the pgbouncer liveness probe
+  ##       and minikube does not allow pods to access their own `cluster.local` service so would otherwise fail
+  DATABASE_PSQL_CMD: "ZWNobyAtbiAicG9zdGdyZXNxbDovLyQoZXZhbCAkREFUQUJBU0VfVVNFUl9DTUQpOiQoZXZhbCAkREFUQUJBU0VfUEFTU1dPUkRfQ01EKUAxMjcuMC4wLjE6JHtEQVRBQkFTRV9QT1JUfS8ke0RBVEFCQVNFX0RCfSR7REFUQUJBU0VfUFJPUEVSVElFU30i"
+
+  ## ================
+  ## Redis Configs
+  ## ================
+
+  ## ================
+  ## Airflow Configs (General)
+  ## ================
+  AIRFLOW__CORE__DAGS_FOLDER: "L29wdC9haXJmbG93L2RhZ3M="
+  AIRFLOW__CORE__EXECUTOR: "S3ViZXJuZXRlc0V4ZWN1dG9y"
+  AIRFLOW__CORE__FERNET_KEY: "N1Q1MTJVWFNTbUJPa3BXaW1GSElWYjhqSzZsZm1TQXZ4NG1PNkFyZWhuYz0="
+  AIRFLOW__WEBSERVER__SECRET_KEY: "VEhJUyBJUyBVTlNBRkUh"
+  AIRFLOW__WEBSERVER__WEB_SERVER_PORT: "ODA4MA=="
+  AIRFLOW__CELERY__FLOWER_PORT: "NTU1NQ=="
+
+  ## ================
+  ## Airflow Configs (Database)
+  ## ================
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: "YmFzaCAtYyAnZXZhbCAiJERBVEFCQVNFX1NRTEFMQ0hFTVlfQ01EIic="
+  ## `core.sql_alchemy_conn` moved to `database.sql_alchemy_conn` in airflow 2.3.0
+  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD: "YmFzaCAtYyAnZXZhbCAiJERBVEFCQVNFX1NRTEFMQ0hFTVlfQ01EIic="
+
+  ## ================
+  ## Airflow Configs (Triggerer)
+  ## ================
+  AIRFLOW__TRIGGERER__DEFAULT_CAPACITY: "MTAwMA=="
+
+  ## ================
+  ## Airflow Configs (Logging)
+  ## ================
+  AIRFLOW__LOGGING__BASE_LOG_FOLDER: "L29wdC9haXJmbG93L2xvZ3M="
+  AIRFLOW__LOGGING__DAG_PROCESSOR_MANAGER_LOG_LOCATION: "L29wdC9haXJmbG93L2xvZ3MvZGFnX3Byb2Nlc3Nvcl9tYW5hZ2VyL2RhZ19wcm9jZXNzb3JfbWFuYWdlci5sb2c="
+  AIRFLOW__SCHEDULER__CHILD_PROCESS_LOG_DIRECTORY: "L29wdC9haXJmbG93L2xvZ3Mvc2NoZWR1bGVy"
+
+  ## ================
+  ## Airflow Configs (Celery)
+  ## ================
+
+  ## ================
+  ## Airflow Configs (Kubernetes)
+  ## ================
+  AIRFLOW__KUBERNETES__NAMESPACE: "YWlyZmxvdw=="
+  AIRFLOW__KUBERNETES_EXECUTOR__NAMESPACE: "YWlyZmxvdw=="
+  AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY: "YXBhY2hlL2FpcmZsb3c="
+  AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_REPOSITORY: "YXBhY2hlL2FpcmZsb3c="
+  AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: "Mi41LjMtcHl0aG9uMy44"
+  AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_TAG: "Mi41LjMtcHl0aG9uMy44"
+  AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE: "L29wdC9haXJmbG93L3BvZF90ZW1wbGF0ZXMvcG9kX3RlbXBsYXRlLnlhbWw="
+  AIRFLOW__KUBERNETES_EXECUTOR__POD_TEMPLATE_FILE: "L29wdC9haXJmbG93L3BvZF90ZW1wbGF0ZXMvcG9kX3RlbXBsYXRlLnlhbWw="
+
+  ## ================
+  ## User Configs
+  ## ================
+  "AIRFLOW__CORE__LOAD_EXAMPLES": "RmFsc2U="
+  "AIRFLOW__WEBSERVER__EXPOSE_CONFIG": "RmFsc2U="
+---
+# Source: airflow/templates/config/secret-webserver-config.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-webserver-config
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+data:
+  webserver_config.py: "ZnJvbSBhaXJmbG93IGltcG9ydCBjb25maWd1cmF0aW9uIGFzIGNvbmYKZnJvbSBmbGFza19hcHBidWlsZGVyLnNlY3VyaXR5Lm1hbmFnZXIgaW1wb3J0IEFVVEhfREIKCiMgdGhlIFNRTEFsY2hlbXkgY29ubmVjdGlvbiBzdHJpbmcKU1FMQUxDSEVNWV9EQVRBQkFTRV9VUkkgPSBjb25mLmdldCgiY29yZSIsICJTUUxfQUxDSEVNWV9DT05OIikKCiMgdXNlIGVtYmVkZGVkIERCIGZvciBhdXRoCkFVVEhfVFlQRSA9IEFVVEhfREIK"
+---
+# Source: airflow/templates/db-migrations/db-migrations-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-db-migrations
+  labels:
+    app: airflow
+    component: db-migrations
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+data:
+  db_migrations.py: "CiMjIyMjIyMjIyMjIyMKIyMgSW1wb3J0cyAjIwojIyMjIyMjIyMjIyMjCmltcG9ydCBsb2dnaW5nCmltcG9ydCB0aW1lCmZyb20gYWlyZmxvdy51dGlscy5kYiBpbXBvcnQgdXBncmFkZWRiCgoKIyMjIyMjIyMjIyMjIwojIyBDb25maWdzICMjCiMjIyMjIyMjIyMjIyMKbG9nID0gbG9nZ2luZy5nZXRMb2dnZXIoX19maWxlX18pCmxvZy5zZXRMZXZlbCgiSU5GTyIpCgojIGhvdyBmcmVxdWVudGx5IHRvIGNoZWNrIGZvciB1bmFwcGxpZWQgbWlncmF0aW9ucwpDT05GX19DSEVDS19NSUdSQVRJT05TX0lOVEVSVkFMID0gMzAwCgoKIyMjIyMjIyMjIyMjIyMjCiMjIEZ1bmN0aW9ucyAjIwojIyMjIyMjIyMjIyMjIyMKZnJvbSBhaXJmbG93LnV0aWxzLmRiIGltcG9ydCBjaGVja19taWdyYXRpb25zCgoKZGVmIG5lZWRzX2RiX21pZ3JhdGlvbnMoKSAtPiBib29sOgogICAgIiIiCiAgICBSZXR1cm4gYSBib29sZWFuIHJlcHJlc2VudGluZyBpZiB0aGUgZGF0YWJhc2UgaGFzIHVuYXBwbGllZCBtaWdyYXRpb25zLgogICAgIiIiCiAgICBsb2dfYWxlbWJpYyA9IGxvZ2dpbmcuZ2V0TG9nZ2VyKCJhbGVtYmljLnJ1bnRpbWUubWlncmF0aW9uIikKICAgIGxvZ19hbGVtYmljX2xldmVsID0gbG9nX2FsZW1iaWMubGV2ZWwKICAgIHRyeToKICAgICAgICBsb2dfYWxlbWJpYy5zZXRMZXZlbCgiV0FSTiIpCiAgICAgICAgY2hlY2tfbWlncmF0aW9ucygxKQogICAgICAgIGxvZ19hbGVtYmljLnNldExldmVsKGxvZ19hbGVtYmljX2xldmVsKQogICAgICAgIHJldHVybiBGYWxzZQogICAgZXhjZXB0IFRpbWVvdXRFcnJvcjoKICAgICAgICByZXR1cm4gVHJ1ZQoKCmRlZiBhcHBseV9kYl9taWdyYXRpb25zKCkgLT4gTm9uZToKICAgICIiIgogICAgQXBwbHkgYW55IHBlbmRpbmcgREIgbWlncmF0aW9ucy4KICAgICIiIgogICAgbG9nLmluZm8oIi0tLS0tLS0tIFNUQVJUIC0gQVBQTFkgREIgTUlHUkFUSU9OUyAtLS0tLS0tLSIpCiAgICB1cGdyYWRlZGIoKQogICAgbG9nLmluZm8oIi0tLS0tLS0tIEZJTklTSCAtIEFQUExZIERCIE1JR1JBVElPTlMgLS0tLS0tLS0iKQoKCmRlZiBtYWluKHN5bmNfZm9yZXZlcjogYm9vbCk6CiAgICAjIGluaXRpYWwgY2hlY2sgJiBhcHBseQogICAgaWYgbmVlZHNfZGJfbWlncmF0aW9ucygpOgogICAgICAgIGxvZy53YXJuaW5nKCJ0aGVyZSBhcmUgdW5hcHBsaWVkIGRiIG1pZ3JhdGlvbnMsIHRyaWdnZXJpbmcgYXBwbHkuLi4iKQogICAgICAgIGFwcGx5X2RiX21pZ3JhdGlvbnMoKQogICAgZWxzZToKICAgICAgICBsb2cuaW5mbygidGhlcmUgYXJlIG5vIHVuYXBwbGllZCBkYiBtaWdyYXRpb25zLCBjb250aW51aW5nLi4uIikKCiAgICBpZiBzeW5jX2ZvcmV2ZXI6CiAgICAgICAgIyBkZWZpbmUgdmFyaWFibGUgdG8gdHJhY2sgaG93IGxvbmcgc2luY2UgbGFzdCBtaWdyYXRpb25zIGNoZWNrCiAgICAgICAgbWlncmF0aW9uc19jaGVja19lcG9jaCA9IHRpbWUudGltZSgpCgogICAgICAgICMgbWFpbiBsb29wCiAgICAgICAgd2hpbGUgVHJ1ZToKICAgICAgICAgICAgaWYgKHRpbWUudGltZSgpIC0gbWlncmF0aW9uc19jaGVja19lcG9jaCkgPiBDT05GX19DSEVDS19NSUdSQVRJT05TX0lOVEVSVkFMOgogICAgICAgICAgICAgICAgbG9nLmRlYnVnKGYiY2hlY2sgaW50ZXJ2YWwgcmVhY2hlZCwgY2hlY2tpbmcgZm9yIHVuYXBwbGllZCBkYiBtaWdyYXRpb25zLi4uIikKICAgICAgICAgICAgICAgIGlmIG5lZWRzX2RiX21pZ3JhdGlvbnMoKToKICAgICAgICAgICAgICAgICAgICBsb2cud2FybmluZygidGhlcmUgYXJlIHVuYXBwbGllZCBkYiBtaWdyYXRpb25zLCB0cmlnZ2VyaW5nIGFwcGx5Li4uIikKICAgICAgICAgICAgICAgICAgICBhcHBseV9kYl9taWdyYXRpb25zKCkKICAgICAgICAgICAgICAgIG1pZ3JhdGlvbnNfY2hlY2tfZXBvY2ggPSB0aW1lLnRpbWUoKQoKICAgICAgICAgICAgIyBlbnN1cmUgd2UgZG9udCBsb29wIHRvbyBmYXN0CiAgICAgICAgICAgIHRpbWUuc2xlZXAoMC41KQoKCiMjIyMjIyMjIyMjIyMjCiMjIFJ1biBNYWluICMjCiMjIyMjIyMjIyMjIyMjCm1haW4oc3luY19mb3JldmVyPVRydWUp"
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-pgbouncer
+  labels:
+    app: airflow
+    component: pgbouncer
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+data:
+  pgbouncer.ini: "CltkYXRhYmFzZXNdCiogPSBob3N0PWFpcmZsb3ctcG9zdGdyZXNxbC5haXJmbG93LnN2Yy5jbHVzdGVyLmxvY2FsIHBvcnQ9NTQzMgoKW3BnYm91bmNlcl0KcG9vbF9tb2RlID0gdHJhbnNhY3Rpb24KbWF4X2NsaWVudF9jb25uID0gMTAwMApkZWZhdWx0X3Bvb2xfc2l6ZSA9ICAyMAppZ25vcmVfc3RhcnR1cF9wYXJhbWV0ZXJzID0gZXh0cmFfZmxvYXRfZGlnaXRzCgpsaXN0ZW5fcG9ydCA9IDY0MzIKbGlzdGVuX2FkZHIgPSAqCgphdXRoX3R5cGUgPSBtZDUKYXV0aF9maWxlID0gL2hvbWUvcGdib3VuY2VyL3VzZXJzLnR4dAoKbG9nX2Rpc2Nvbm5lY3Rpb25zID0gMApsb2dfY29ubmVjdGlvbnMgPSAwCgojIGxvY2tzIHdpbGwgbmV2ZXIgYmUgcmVsZWFzZWQgd2hlbiBgcG9vbF9tb2RlPXRyYW5zYWN0aW9uYCAoYWlyZmxvdyBpbml0ZGIvdXBncmFkZWRiIHNjcmlwdHMgY3JlYXRlIGxvY2tzKQpzZXJ2ZXJfcmVzZXRfcXVlcnkgPSBTRUxFQ1QgcGdfYWR2aXNvcnlfdW5sb2NrX2FsbCgpCnNlcnZlcl9yZXNldF9xdWVyeV9hbHdheXMgPSAxCgojIyBDTElFTlQgVExTIFNFVFRJTkdTICMjCmNsaWVudF90bHNfc3NsbW9kZSA9IHByZWZlcgpjbGllbnRfdGxzX2NpcGhlcnMgPSBub3JtYWwKY2xpZW50X3Rsc19rZXlfZmlsZSA9IC9ob21lL3BnYm91bmNlci9nZW5lcmF0ZWQtY2VydHMvY2xpZW50LmtleQpjbGllbnRfdGxzX2NlcnRfZmlsZSA9IC9ob21lL3BnYm91bmNlci9nZW5lcmF0ZWQtY2VydHMvY2xpZW50LmNydAoKIyMgU0VSVkVSIFRMUyBTRVRUSU5HUyAjIwpzZXJ2ZXJfdGxzX3NzbG1vZGUgPSBwcmVmZXIKc2VydmVyX3Rsc19jaXBoZXJzID0gbm9ybWFs"
+  gen_auth_file.sh: "CiMhL2Jpbi9zaCAtZQoKIyBERVNDUklQVElPTjoKIyAtIHVwZGF0ZXMgdGhlIHBnYm91bmNlciBgYXV0aF9maWxlYCBmcm9tIGVudmlyb25tZW50IHZhcmlhYmxlcwojIC0gY2FsbGVkIGluIG1haW4gcGdib3VuY2VyIGNvbnRhaW5lciBzdGFydC1jb21tYW5kIHNvIHRoYXQgYGF1dGhfZmlsZWAgaXMgdXBkYXRlZCBlYWNoIHJlc3RhcnQsCiMgICBmb3IgZXhhbXBsZSwgd2hlbiB0aGUgbGl2ZW5lc3NQcm9iZSBmYWlscyBkdWUgdG8gYSBEQVRBQkFTRV9QQVNTV09SRCBzZWNyZXQgdXBkYXRlCgojIHZhcmlhYmxlcyB0byBpbmNyZWFzZSBjbGFyaXR5IG9mIHBhdHRlcm4gbWF0Y2hpbmcKT05FX1FVT1RFPSciJwpUV09fUVVPVEU9JyIiJwoKIyBwZ2JvdW5jZXIgcmVxdWlyZXMgYCJgIHRvIGJlIGVzY2FwZWQgYXMgYCIiYApFU0NBUEVEX0RBVEFCQVNFX1VTRVI9IiR7REFUQUJBU0VfVVNFUi8kT05FX1FVT1RFLyRUV09fUVVPVEV9IgpFU0NBUEVEX0RBVEFCQVNFX1BBU1NXT1JEPSIke0RBVEFCQVNFX1BBU1NXT1JELyRPTkVfUVVPVEUvJFRXT19RVU9URX0iCgojIHBnYm91bmNlciByZXF1aXJlcyBhdXRoX2ZpbGUgaW4gZm9ybWF0IGAibXktdXNlcm5hbWUiICJteS1wYXNzd29yZCJgCmVjaG8gXCIkRVNDQVBFRF9EQVRBQkFTRV9VU0VSXCIgXCIkRVNDQVBFRF9EQVRBQkFTRV9QQVNTV09SRFwiID4gL2hvbWUvcGdib3VuY2VyL3VzZXJzLnR4dAplY2hvICJTdWNjZXNzZnVsbHkgZ2VuZXJhdGVkIGF1dGhfZmlsZTogL2hvbWUvcGdib3VuY2VyL3VzZXJzLnR4dCI="
+  gen_self_signed_cert.sh: "CiMhL2Jpbi9zaCAtZQoKQ0VSVF9ESVI9Ii9ob21lL3BnYm91bmNlci9nZW5lcmF0ZWQtY2VydHMiCktFWV9GSUxFPSIkQ0VSVF9ESVIvY2xpZW50LmtleSIKQ0VSVF9GSUxFPSIkQ0VSVF9ESVIvY2xpZW50LmNydCIKCiMgY3JlYXRlIHRoZSBkaXJlY3RvcnkgZm9yIHRoZSBzZWxmLXNpZ25lZCBjZXJ0aWZpY2F0ZQpta2RpciAtcCAiJENFUlRfRElSIgoKIyB2YXJpYWJsZXMgZm9yIGNlcnRpZmljYXRlIGdlbmVyYXRpb24KQ09NTU9OX05BTUU9ImxvY2FsaG9zdCIKREFZU19WQUxJRD0zNjUKCiMgZ2VuZXJhdGUgdGhlIHNlbGYtc2lnbmVkIGNlcnRpZmljYXRlIGFuZCBhIHByaXZhdGUga2V5Cm9wZW5zc2wgcmVxIC14NTA5IFwKICAtbmV3a2V5IHJzYTo0MDk2IFwKICAta2V5b3V0ICIkS0VZX0ZJTEUiIFwKICAtb3V0ICIkQ0VSVF9GSUxFIiBcCiAgLWRheXMgIiREQVlTX1ZBTElEIiBcCiAgLXN1YmogIi9DTj0kQ09NTU9OX05BTUUiIFwKICAtbm9kZXMKCiMgc2V0IHBlcm1pc3Npb25zIGZvciB0aGUgcHJpdmF0ZSBrZXkgZmlsZQpjaG1vZCA2MDAgIiRLRVlfRklMRSIKCmVjaG8gIlN1Y2Nlc3NmdWxseSBnZW5lcmF0ZWQgc2VsZi1zaWduZWQgY2VydGlmaWNhdGU6ICRDRVJUX0ZJTEUiCmVjaG8gIlN1Y2Nlc3NmdWxseSBnZW5lcmF0ZWQgc2VsZi1zaWduZWQgY2VydGlmaWNhdGUga2V5OiAkS0VZX0ZJTEUi"
+---
+# Source: airflow/templates/sync/sync-users-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-sync-users
+  labels:
+    app: airflow
+    component: sync-users
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+data:
+  sync_users.py: "CiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMKIyMjIyBCRUdJTjogR0xPQkFMIENPREUgIyMjIwojIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjCiMjIyMjIyMjIyMjIyMjIyMjIyMjCiMjIEdsb2JhbCBJbXBvcnRzICMjCiMjIyMjIyMjIyMjIyMjIyMjIyMjCmltcG9ydCBsb2dnaW5nCmltcG9ydCBvcwppbXBvcnQgdGltZQpmcm9tIHN0cmluZyBpbXBvcnQgVGVtcGxhdGUKZnJvbSB0eXBpbmcgaW1wb3J0IExpc3QsIERpY3QsIE9wdGlvbmFsCgoKIyMjIyMjIyMjIyMjIyMjIyMjIyMKIyMgR2xvYmFsIENvbmZpZ3MgIyMKIyMjIyMjIyMjIyMjIyMjIyMjIyMKIyB0aGUgcGF0aCB3aGljaCBTZWNyZXQvQ29uZmlnTWFwIGFyZSBtb3VudGVkIHRvCkNPTkZfX1RFTVBMQVRFU19QQVRIID0gIi9tbnQvdGVtcGxhdGVzIgoKIyBob3cgZnJlcXVlbnRseSB0byBjaGVjayBmb3IgU2VjcmV0L0NvbmZpZ01hcCB1cGRhdGVzCkNPTkZfX1RFTVBMQVRFU19TWU5DX0lOVEVSVkFMID0gMTAKCiMgaG93IGZyZXF1ZW50bHkgdG8gcmUtc3luYyBvYmplY3RzIChDb25uZWN0aW9ucywgUG9vbHMsIFVzZXJzLCBWYXJpYWJsZXMpCkNPTkZfX09CSkVDVFNfU1lOQ19JTlRFUlZBTCA9IDYwCgoKIyMjIyMjIyMjIyMjIyMjIyMjIyMjIwojIyBHbG9iYWwgRnVuY3Rpb25zICMjCiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMKZGVmIHN0cmluZ19zdWJzdGl0dXRpb24ocmF3X3N0cmluZzogT3B0aW9uYWxbc3RyXSwgc3Vic3RpdHV0aW9uX21hcDogRGljdFtzdHIsIHN0cl0pIC0+IHN0cjoKICAgICIiIgogICAgQXBwbHkgYmFzaC1saWtlIHN1YnN0aXR1dGlvbnMgdG8gYSByYXcgc3RyaW5nLgoKICAgIEV4YW1wbGU6CiAgICAtIHN0cmluZ19zdWJzdGl0dXRpb24oIkhlbGxvISIsIE5vbmUpIC0+ICJIZWxsbyEiCiAgICAtIHN0cmluZ19zdWJzdGl0dXRpb24oIkhlbGxvICR7TkFNRX0hIiwgeyJOQU1FIjogIkFpcmZsb3cifSkgLT4gIkhlbGxvIEFpcmZsb3chIgogICAgIiIiCiAgICBpZiByYXdfc3RyaW5nIGFuZCBsZW4oc3Vic3RpdHV0aW9uX21hcCkgPiAwOgogICAgICAgIHRwbCA9IFRlbXBsYXRlKHJhd19zdHJpbmcpCiAgICAgICAgcmV0dXJuIHRwbC5zYWZlX3N1YnN0aXR1dGUoc3Vic3RpdHV0aW9uX21hcCkKICAgIGVsc2U6CiAgICAgICAgcmV0dXJuIHJhd19zdHJpbmcKCgpkZWYgdGVtcGxhdGVfbXRpbWUodGVtcGxhdGVfbmFtZTogc3RyKSAtPiBmbG9hdDoKICAgICIiIgogICAgUmV0dXJuIHRoZSBtb2RpZmljYXRpb24tdGltZSBvZiB0aGUgZmlsZSBzdG9yaW5nIGB0ZW1wbGF0ZV9uYW1lYAogICAgIiIiCiAgICBmaWxlX3BhdGggPSBmIntDT05GX19URU1QTEFURVNfUEFUSH0ve3RlbXBsYXRlX25hbWV9IgogICAgcmV0dXJuIG9zLnN0YXQoZmlsZV9wYXRoKS5zdF9tdGltZQoKCmRlZiB0ZW1wbGF0ZV92YWx1ZSh0ZW1wbGF0ZV9uYW1lOiBzdHIpIC0+IHN0cjoKICAgICIiIgogICAgUmV0dXJuIHRoZSBjb250ZW50cyBvZiB0aGUgZmlsZSBzdG9yaW5nIGB0ZW1wbGF0ZV9uYW1lYAogICAgIiIiCiAgICBmaWxlX3BhdGggPSBmIntDT05GX19URU1QTEFURVNfUEFUSH0ve3RlbXBsYXRlX25hbWV9IgogICAgd2l0aCBvcGVuKGZpbGVfcGF0aCwgInIiKSBhcyBmOgogICAgICAgIHJldHVybiBmLnJlYWQoKQoKCmRlZiByZWZyZXNoX3RlbXBsYXRlX2NhY2hlKHRlbXBsYXRlX25hbWVzOiBMaXN0W3N0cl0sCiAgICAgICAgICAgICAgICAgICAgICAgICAgIHRlbXBsYXRlX210aW1lX2NhY2hlOiBEaWN0W3N0ciwgZmxvYXRdLAogICAgICAgICAgICAgICAgICAgICAgICAgICB0ZW1wbGF0ZV92YWx1ZV9jYWNoZTogRGljdFtzdHIsIHN0cl0pIC0+IExpc3Rbc3RyXToKICAgICIiIgogICAgUmVmcmVzaCB0aGUgcHJvdmlkZWQgZGljdGlvbmFyeSBjYWNoZXMgb2YgdGVtcGxhdGUgdmFsdWVzICYgbXRpbWVzLgoKICAgIDpwYXJhbSB0ZW1wbGF0ZV9uYW1lczogdGhlIG5hbWVzIG9mIGFsbCB0ZW1wbGF0ZXMgdG8gcmVmcmVzaAogICAgOnBhcmFtIHRlbXBsYXRlX210aW1lX2NhY2hlOiB0aGUgZGljdGlvbmFyeSBjYWNoZSBvZiB0ZW1wbGF0ZSBmaWxlIG1vZGlmaWNhdGlvbi10aW1lcwogICAgOnBhcmFtIHRlbXBsYXRlX3ZhbHVlX2NhY2hlOiB0aGUgZGljdGlvbmFyeSBjYWNoZSBvZiB0ZW1wbGF0ZSB2YWx1ZXMKICAgIDpyZXR1cm46IHRoZSBuYW1lcyBvZiB0ZW1wbGF0ZXMgd2hpY2ggY2hhbmdlZAogICAgIiIiCiAgICBjaGFuZ2VkX3RlbXBsYXRlcyA9IFtdCiAgICBmb3IgdGVtcGxhdGVfbmFtZSBpbiB0ZW1wbGF0ZV9uYW1lczoKICAgICAgICBvbGRfbXRpbWUgPSB0ZW1wbGF0ZV9tdGltZV9jYWNoZS5nZXQodGVtcGxhdGVfbmFtZSwgTm9uZSkKICAgICAgICBuZXdfbXRpbWUgPSB0ZW1wbGF0ZV9tdGltZSh0ZW1wbGF0ZV9uYW1lKQogICAgICAgICMgZmlyc3QsIGNoZWNrIGlmIHRoZSBmaWxlcyB3ZXJlIG1vZGlmaWVkCiAgICAgICAgaWYgb2xkX210aW1lICE9IG5ld19tdGltZToKICAgICAgICAgICAgb2xkX3ZhbHVlID0gdGVtcGxhdGVfdmFsdWVfY2FjaGUuZ2V0KHRlbXBsYXRlX25hbWUsIE5vbmUpCiAgICAgICAgICAgIG5ld192YWx1ZSA9IHRlbXBsYXRlX3ZhbHVlKHRlbXBsYXRlX25hbWUpCiAgICAgICAgICAgICMgc2Vjb25kLCBjaGVjayBpZiB0aGUgdmFsdWUgYWN0dWFsbHkgY2hhbmdlZAogICAgICAgICAgICBpZiBvbGRfdmFsdWUgIT0gbmV3X3ZhbHVlOgogICAgICAgICAgICAgICAgdGVtcGxhdGVfdmFsdWVfY2FjaGVbdGVtcGxhdGVfbmFtZV0gPSBuZXdfdmFsdWUKICAgICAgICAgICAgICAgIGNoYW5nZWRfdGVtcGxhdGVzICs9IFt0ZW1wbGF0ZV9uYW1lXQogICAgICAgICAgICB0ZW1wbGF0ZV9tdGltZV9jYWNoZVt0ZW1wbGF0ZV9uYW1lXSA9IG5ld19tdGltZQogICAgcmV0dXJuIGNoYW5nZWRfdGVtcGxhdGVzCgoKZGVmIG1haW4oc3luY19mb3JldmVyOiBib29sKToKICAgICMgaW5pdGlhbCBzeW5jIG9mIHRlbXBsYXRlIGNhY2hlCiAgICByZWZyZXNoX3RlbXBsYXRlX2NhY2hlKAogICAgICAgIHRlbXBsYXRlX25hbWVzPVZBUl9fVEVNUExBVEVfTkFNRVMsCiAgICAgICAgdGVtcGxhdGVfbXRpbWVfY2FjaGU9VkFSX19URU1QTEFURV9NVElNRV9DQUNIRSwKICAgICAgICB0ZW1wbGF0ZV92YWx1ZV9jYWNoZT1WQVJfX1RFTVBMQVRFX1ZBTFVFX0NBQ0hFCiAgICApCgogICAgIyBpbml0aWFsIHN5bmMgb2Ygb2JqZWN0cyBpbnRvIEFpcmZsb3cgREIKICAgIHN5bmNfd2l0aF9haXJmbG93KCkKCiAgICBpZiBzeW5jX2ZvcmV2ZXI6CiAgICAgICAgIyBkZWZpbmUgdmFyaWFibGVzIHVzZWQgdG8gdHJhY2sgaG93IGxvbmcgc2luY2UgbGFzdCByZWZyZXNoL3N5bmMKICAgICAgICB0ZW1wbGF0ZXNfc3luY19lcG9jaCA9IHRpbWUudGltZSgpCiAgICAgICAgb2JqZWN0c19zeW5jX2Vwb2NoID0gdGltZS50aW1lKCkKCiAgICAgICAgIyBtYWluIGxvb3AKICAgICAgICB3aGlsZSBUcnVlOgogICAgICAgICAgICAjIG1vbml0b3IgZm9yIHRlbXBsYXRlIHNlY3JldC9jb25maWdtYXAgdXBkYXRlcwogICAgICAgICAgICBpZiAodGltZS50aW1lKCkgLSB0ZW1wbGF0ZXNfc3luY19lcG9jaCkgPiBDT05GX19URU1QTEFURVNfU1lOQ19JTlRFUlZBTDoKICAgICAgICAgICAgICAgIGxvZ2dpbmcuZGVidWcoZiJ0ZW1wbGF0ZSBzeW5jIGludGVydmFsIHJlYWNoZWQsIHJlLXN5bmNpbmcgYWxsIHRlbXBsYXRlcy4uLiIpCiAgICAgICAgICAgICAgICBjaGFuZ2VkX3RlbXBsYXRlcyA9IHJlZnJlc2hfdGVtcGxhdGVfY2FjaGUoCiAgICAgICAgICAgICAgICAgICAgdGVtcGxhdGVfbmFtZXM9VkFSX19URU1QTEFURV9OQU1FUywKICAgICAgICAgICAgICAgICAgICB0ZW1wbGF0ZV9tdGltZV9jYWNoZT1WQVJfX1RFTVBMQVRFX01USU1FX0NBQ0hFLAogICAgICAgICAgICAgICAgICAgIHRlbXBsYXRlX3ZhbHVlX2NhY2hlPVZBUl9fVEVNUExBVEVfVkFMVUVfQ0FDSEUKICAgICAgICAgICAgICAgICkKICAgICAgICAgICAgICAgIHRlbXBsYXRlc19zeW5jX2Vwb2NoID0gdGltZS50aW1lKCkKICAgICAgICAgICAgICAgIGlmIGNoYW5nZWRfdGVtcGxhdGVzOgogICAgICAgICAgICAgICAgICAgIGxvZ2dpbmcuaW5mbyhmInRlbXBsYXRlIHZhbHVlcyBoYXZlIGNoYW5nZWQ6IFt7JywnLmpvaW4oY2hhbmdlZF90ZW1wbGF0ZXMpfV0iKQogICAgICAgICAgICAgICAgICAgIHN5bmNfd2l0aF9haXJmbG93KCkKICAgICAgICAgICAgICAgICAgICBvYmplY3RzX3N5bmNfZXBvY2ggPSB0aW1lLnRpbWUoKQoKICAgICAgICAgICAgIyBtb25pdG9yIGZvciBleHRlcm5hbCBjaGFuZ2VzIHRvIG9iamVjdHMgKGxpa2UgZnJvbSBVSSkKICAgICAgICAgICAgaWYgKHRpbWUudGltZSgpIC0gb2JqZWN0c19zeW5jX2Vwb2NoKSA+IENPTkZfX09CSkVDVFNfU1lOQ19JTlRFUlZBTDoKICAgICAgICAgICAgICAgIGxvZ2dpbmcuZGVidWcoZiJzeW5jIGludGVydmFsIHJlYWNoZWQsIHJlLXN5bmNpbmcgYWxsIG9iamVjdHMuLi4iKQogICAgICAgICAgICAgICAgc3luY193aXRoX2FpcmZsb3coKQogICAgICAgICAgICAgICAgb2JqZWN0c19zeW5jX2Vwb2NoID0gdGltZS50aW1lKCkKCiAgICAgICAgICAgICMgZW5zdXJlIHdlIGRvbnQgbG9vcCB0b28gZmFzdAogICAgICAgICAgICB0aW1lLnNsZWVwKDAuNSkKIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMKIyMjIyBFTkQ6IEdMT0JBTCBDT0RFICMjIyMKIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMKCgojIyMjIyMjIyMjIyMjCiMjIEltcG9ydHMgIyMKIyMjIyMjIyMjIyMjIwppbXBvcnQgc3lzCmZyb20gd2Vya3pldWcuc2VjdXJpdHkgaW1wb3J0IGNoZWNrX3Bhc3N3b3JkX2hhc2gsIGdlbmVyYXRlX3Bhc3N3b3JkX2hhc2gKaW1wb3J0IGFpcmZsb3cud3d3LmFwcCBhcyB3d3dfYXBwCmZsYXNrX2FwcCA9IHd3d19hcHAuY3JlYXRlX2FwcCgpCmZsYXNrX2FwcGJ1aWxkZXIgPSBmbGFza19hcHAuYXBwYnVpbGRlcgoKIyBhaXJmbG93IHVzZXMgaXRzIG93biBpbmNvbXBhdGlibGUgRkFCIG1vZGVscyBpbiAyLjMuMCsKdHJ5OgogIGZyb20gYWlyZmxvdy53d3cuZmFiX3NlY3VyaXR5LnNxbGEubW9kZWxzIGltcG9ydCBVc2VyLCBSb2xlCmV4Y2VwdCBNb2R1bGVOb3RGb3VuZEVycm9yOgogIGZyb20gZmxhc2tfYXBwYnVpbGRlci5zZWN1cml0eS5zcWxhLm1vZGVscyBpbXBvcnQgVXNlciwgUm9sZQoKCiMjIyMjIyMjIyMjIyMKIyMgQ2xhc3NlcyAjIwojIyMjIyMjIyMjIyMjCmNsYXNzIFVzZXJXcmFwcGVyKG9iamVjdCk6CiAgICBkZWYgX19pbml0X18oCiAgICAgICAgICAgIHNlbGYsCiAgICAgICAgICAgIHVzZXJuYW1lOiBzdHIsCiAgICAgICAgICAgIGZpcnN0X25hbWU6IE9wdGlvbmFsW3N0cl0gPSBOb25lLAogICAgICAgICAgICBsYXN0X25hbWU6IE9wdGlvbmFsW3N0cl0gPSBOb25lLAogICAgICAgICAgICBlbWFpbDogT3B0aW9uYWxbc3RyXSA9IE5vbmUsCiAgICAgICAgICAgIHJvbGVzOiBPcHRpb25hbFtMaXN0W3N0cl1dID0gTm9uZSwKICAgICAgICAgICAgcGFzc3dvcmQ6IE9wdGlvbmFsW3N0cl0gPSBOb25lCiAgICApOgogICAgICAgIHNlbGYudXNlcm5hbWUgPSB1c2VybmFtZQogICAgICAgIHNlbGYuX2ZpcnN0X25hbWUgPSBmaXJzdF9uYW1lCiAgICAgICAgc2VsZi5fbGFzdF9uYW1lID0gbGFzdF9uYW1lCiAgICAgICAgc2VsZi5fZW1haWwgPSBlbWFpbAogICAgICAgIHNlbGYucm9sZXMgPSByb2xlcwogICAgICAgIHNlbGYuX3Bhc3N3b3JkID0gcGFzc3dvcmQKCiAgICBAcHJvcGVydHkKICAgIGRlZiBmaXJzdF9uYW1lKHNlbGYpIC0+IHN0cjoKICAgICAgICByZXR1cm4gc3RyaW5nX3N1YnN0aXR1dGlvbihzZWxmLl9maXJzdF9uYW1lLCBWQVJfX1RFTVBMQVRFX1ZBTFVFX0NBQ0hFKQoKICAgIEBwcm9wZXJ0eQogICAgZGVmIGxhc3RfbmFtZShzZWxmKSAtPiBzdHI6CiAgICAgICAgcmV0dXJuIHN0cmluZ19zdWJzdGl0dXRpb24oc2VsZi5fbGFzdF9uYW1lLCBWQVJfX1RFTVBMQVRFX1ZBTFVFX0NBQ0hFKQoKICAgIEBwcm9wZXJ0eQogICAgZGVmIGVtYWlsKHNlbGYpIC0+IHN0cjoKICAgICAgICByZXR1cm4gc3RyaW5nX3N1YnN0aXR1dGlvbihzZWxmLl9lbWFpbCwgVkFSX19URU1QTEFURV9WQUxVRV9DQUNIRSkKCiAgICBAcHJvcGVydHkKICAgIGRlZiBwYXNzd29yZChzZWxmKSAtPiBzdHI6CiAgICAgICAgcmV0dXJuIHN0cmluZ19zdWJzdGl0dXRpb24oc2VsZi5fcGFzc3dvcmQsIFZBUl9fVEVNUExBVEVfVkFMVUVfQ0FDSEUpCgogICAgZGVmIGFzX2RpY3Qoc2VsZikgLT4gRGljdFtzdHIsIHN0cl06CiAgICAgICAgcmV0dXJuIHsKICAgICAgICAgICAgInVzZXJuYW1lIjogc2VsZi51c2VybmFtZSwKICAgICAgICAgICAgImZpcnN0X25hbWUiOiBzZWxmLmZpcnN0X25hbWUsCiAgICAgICAgICAgICJsYXN0X25hbWUiOiBzZWxmLmxhc3RfbmFtZSwKICAgICAgICAgICAgImVtYWlsIjogc2VsZi5lbWFpbCwKICAgICAgICAgICAgInJvbGVzIjogW2ZpbmRfcm9sZShyb2xlX25hbWU9cm9sZV9uYW1lKSBmb3Igcm9sZV9uYW1lIGluIHNlbGYucm9sZXNdLAogICAgICAgICAgICAicGFzc3dvcmQiOiBzZWxmLnBhc3N3b3JkCiAgICAgICAgfQoKCiMjIyMjIyMjIyMjIyMjIwojIyBWYXJpYWJsZXMgIyMKIyMjIyMjIyMjIyMjIyMjClZBUl9fVEVNUExBVEVfTkFNRVMgPSBbCl0KVkFSX19URU1QTEFURV9NVElNRV9DQUNIRSA9IHt9ClZBUl9fVEVNUExBVEVfVkFMVUVfQ0FDSEUgPSB7fQpWQVJfX1VTRVJfV1JBUFBFUlMgPSB7CiAgImFkbWluIjogVXNlcldyYXBwZXIoCiAgICB1c2VybmFtZT0iYWRtaW4iLAogICAgZmlyc3RfbmFtZT0iYWRtaW4iLAogICAgbGFzdF9uYW1lPSJhZG1pbiIsCiAgICBlbWFpbD0iYWRtaW5AZXhhbXBsZS5jb20iLAogICAgcm9sZXM9WyAgICAgICAgIkFkbWluIiwKICAgIF0sCiAgICBwYXNzd29yZD0iYWRtaW4iLAogICksCn0KCgojIyMjIyMjIyMjIyMjIyMKIyMgRnVuY3Rpb25zICMjCiMjIyMjIyMjIyMjIyMjIwpkZWYgZmluZF9yb2xlKHJvbGVfbmFtZTogc3RyKSAtPiBSb2xlOgogICAgIiIiCiAgICBHZXQgdGhlIEZBQiBSb2xlIG1vZGVsIGFzc29jaWF0ZWQgd2l0aCBhIGByb2xlX25hbWVgLgogICAgIiIiCiAgICBmb3VuZF9yb2xlID0gZmxhc2tfYXBwYnVpbGRlci5zbS5maW5kX3JvbGUocm9sZV9uYW1lKQogICAgaWYgZm91bmRfcm9sZToKICAgICAgICByZXR1cm4gZm91bmRfcm9sZQogICAgZWxzZToKICAgICAgICB2YWxpZF9yb2xlcyA9IGZsYXNrX2FwcGJ1aWxkZXIuc20uZ2V0X2FsbF9yb2xlcygpCiAgICAgICAgbG9nZ2luZy5lcnJvcihmIkZhaWxlZCB0byBmaW5kIHJvbGU9YHtyb2xlX25hbWV9YCwgdmFsaWQgcm9sZXMgYXJlOiB7dmFsaWRfcm9sZXN9IikKICAgICAgICBzeXMuZXhpdCgxKQoKCmRlZiBjb21wYXJlX3JvbGVfbGlzdHMocm9sZV9saXN0XzE6IExpc3RbUm9sZV0sIHJvbGVfbGlzdF8yOiBMaXN0W1JvbGVdKSAtPiBib29sOgogICAgIiIiCiAgICBDaGVjayBpZiB0d28gbGlzdHMgb2YgRkFCIFJvbGVzIGNvbnRhaW4gdGhlIHNhbWUgcm9sZXMgKGlnbm9yZXMgZHVwbGljYXRlcyBhbmQgb3JkZXIpLgogICAgIiIiCiAgICBuYW1lX3NldF8xID0gc2V0KHJvbGUubmFtZSBmb3Igcm9sZSBpbiByb2xlX2xpc3RfMSkKICAgIG5hbWVfc2V0XzIgPSBzZXQocm9sZS5uYW1lIGZvciByb2xlIGluIHJvbGVfbGlzdF8yKQogICAgcmV0dXJuIG5hbWVfc2V0XzEgPT0gbmFtZV9zZXRfMgoKCgpkZWYgY29tcGFyZV91c2Vycyh1c2VyX2RpY3Q6IERpY3QsIHVzZXJfbW9kZWw6IFVzZXIpIC0+IGJvb2w6CiAgICAiIiIKICAgIENoZWNrIGlmIHVzZXIgaW5mbyAoc3RvcmVkIGluIGRpY3QpIGlzIGlkZW50aWNhbCB0byBhIEZBQiBVc2VyIG1vZGVsLgogICAgIiIiCiAgICByZXR1cm4gKAogICAgICAgICAgICB1c2VyX2RpY3RbInVzZXJuYW1lIl0gPT0gdXNlcl9tb2RlbC51c2VybmFtZQogICAgICAgICAgICBhbmQgdXNlcl9kaWN0WyJmaXJzdF9uYW1lIl0gPT0gdXNlcl9tb2RlbC5maXJzdF9uYW1lCiAgICAgICAgICAgIGFuZCB1c2VyX2RpY3RbImxhc3RfbmFtZSJdID09IHVzZXJfbW9kZWwubGFzdF9uYW1lCiAgICAgICAgICAgIGFuZCB1c2VyX2RpY3RbImVtYWlsIl0gPT0gdXNlcl9tb2RlbC5lbWFpbAogICAgICAgICAgICBhbmQgY29tcGFyZV9yb2xlX2xpc3RzKHVzZXJfZGljdFsicm9sZXMiXSwgdXNlcl9tb2RlbC5yb2xlcykKICAgICAgICAgICAgYW5kIGNoZWNrX3Bhc3N3b3JkX2hhc2gocHdoYXNoPXVzZXJfbW9kZWwucGFzc3dvcmQsIHBhc3N3b3JkPXVzZXJfZGljdFsicGFzc3dvcmQiXSkKICAgICkKCgpkZWYgc3luY191c2VyKHVzZXJfd3JhcHBlcjogVXNlcldyYXBwZXIpIC0+IE5vbmU6CiAgICAiIiIKICAgIFN5bmMgdGhlIFVzZXIgZGVmaW5lZCBieSBhIHByb3ZpZGVkIFVzZXJXcmFwcGVyIGludG8gdGhlIEZBQiBEQi4KICAgICIiIgogICAgdXNlcm5hbWUgPSB1c2VyX3dyYXBwZXIudXNlcm5hbWUKICAgIHVfbmV3ID0gdXNlcl93cmFwcGVyLmFzX2RpY3QoKQogICAgdV9vbGQgPSBmbGFza19hcHBidWlsZGVyLnNtLmZpbmRfdXNlcih1c2VybmFtZT11c2VybmFtZSkKCiAgICBpZiBub3QgdV9vbGQ6CiAgICAgICAgbG9nZ2luZy5pbmZvKGYiVXNlcj1ge3VzZXJuYW1lfWAgaXMgbWlzc2luZywgYWRkaW5nLi4uIikKICAgICAgICBjcmVhdGVkX3VzZXIgPSBmbGFza19hcHBidWlsZGVyLnNtLmFkZF91c2VyKAogICAgICAgICAgICB1c2VybmFtZT11X25ld1sidXNlcm5hbWUiXSwKICAgICAgICAgICAgZmlyc3RfbmFtZT11X25ld1siZmlyc3RfbmFtZSJdLAogICAgICAgICAgICBsYXN0X25hbWU9dV9uZXdbImxhc3RfbmFtZSJdLAogICAgICAgICAgICBlbWFpbD11X25ld1siZW1haWwiXSwKICAgICAgICAgICAgIyBpbiBvbGQgdmVyc2lvbnMgb2YgZmxhc2tfYXBwYnVpbGRlciBgYWRkX3VzZXIocm9sZT1gIGNhbiBvbmx5IGFkZCBleGFjdGx5IG9uZSByb2xlCiAgICAgICAgICAgICMgKHVuY2hlY2tlZCAwIGluZGV4IGlzIHNhZmUgYmVjYXVzZSB3ZSByZXF1aXJlIGF0IGxlYXN0IG9uZSByb2xlIHVzaW5nIGhlbG0gdmFsdWVzIHZhbGlkYXRpb24pCiAgICAgICAgICAgIHJvbGU9dV9uZXdbInJvbGVzIl1bMF0sCiAgICAgICAgICAgIHBhc3N3b3JkPXVfbmV3WyJwYXNzd29yZCJdCiAgICAgICAgKQogICAgICAgIGlmIGNyZWF0ZWRfdXNlcjoKICAgICAgICAgICAgIyBhZGQgdGhlIGZ1bGwgbGlzdCBvZiByb2xlcyAod2Ugb25seSBhZGRlZCB0aGUgZmlyc3Qgb25lIGFib3ZlKQogICAgICAgICAgICBjcmVhdGVkX3VzZXIucm9sZXMgPSB1X25ld1sicm9sZXMiXQogICAgICAgICAgICBsb2dnaW5nLmluZm8oZiJVc2VyPWB7dXNlcm5hbWV9YCB3YXMgc3VjY2Vzc2Z1bGx5IGFkZGVkLiIpCiAgICAgICAgZWxzZToKICAgICAgICAgICAgbG9nZ2luZy5lcnJvcihmIkZhaWxlZCB0byBhZGQgVXNlcj1ge3VzZXJuYW1lfWAiKQogICAgICAgICAgICBzeXMuZXhpdCgxKQogICAgZWxzZToKICAgICAgICBpZiBjb21wYXJlX3VzZXJzKHVfbmV3LCB1X29sZCk6CiAgICAgICAgICAgIHBhc3MKICAgICAgICBlbHNlOgogICAgICAgICAgICBsb2dnaW5nLmluZm8oZiJVc2VyPWB7dXNlcm5hbWV9YCBleGlzdHMgYnV0IGhhcyBjaGFuZ2VkLCB1cGRhdGluZy4uLiIpCiAgICAgICAgICAgIHVfb2xkLmZpcnN0X25hbWUgPSB1X25ld1siZmlyc3RfbmFtZSJdCiAgICAgICAgICAgIHVfb2xkLmxhc3RfbmFtZSA9IHVfbmV3WyJsYXN0X25hbWUiXQogICAgICAgICAgICB1X29sZC5lbWFpbCA9IHVfbmV3WyJlbWFpbCJdCiAgICAgICAgICAgIHVfb2xkLnJvbGVzID0gdV9uZXdbInJvbGVzIl0KICAgICAgICAgICAgdV9vbGQucGFzc3dvcmQgPSBnZW5lcmF0ZV9wYXNzd29yZF9oYXNoKHVfbmV3WyJwYXNzd29yZCJdKQogICAgICAgICAgICAjIHN0cmFuZ2UgY2hlY2sgZm9yIEZhbHNlIGlzIGJlY2F1c2UgdXBkYXRlX3VzZXIoKSByZXR1cm5zIE5vbmUgZm9yIHN1Y2Nlc3MKICAgICAgICAgICAgIyBidXQgaW4gZnV0dXJlIG1pZ2h0IHJldHVybiB0aGUgVXNlciBtb2RlbAogICAgICAgICAgICBpZiBub3QgKGZsYXNrX2FwcGJ1aWxkZXIuc20udXBkYXRlX3VzZXIodV9vbGQpIGlzIEZhbHNlKToKICAgICAgICAgICAgICAgIGxvZ2dpbmcuaW5mbyhmIlVzZXI9YHt1c2VybmFtZX1gIHdhcyBzdWNjZXNzZnVsbHkgdXBkYXRlZC4iKQogICAgICAgICAgICBlbHNlOgogICAgICAgICAgICAgICAgbG9nZ2luZy5lcnJvcihmIkZhaWxlZCB0byB1cGRhdGUgVXNlcj1ge3VzZXJuYW1lfWAiKQogICAgICAgICAgICAgICAgc3lzLmV4aXQoMSkKCgpkZWYgc3luY19hbGxfdXNlcnModXNlcl93cmFwcGVyczogRGljdFtzdHIsIFVzZXJXcmFwcGVyXSkgLT4gTm9uZToKICAgICIiIgogICAgU3luYyBhbGwgdXNlcnMgaW4gcHJvdmlkZWQgYHVzZXJfd3JhcHBlcnNgLgogICAgIiIiCiAgICBsb2dnaW5nLmluZm8oIkJFR0lOOiBhaXJmbG93IHVzZXJzIHN5bmMiKQogICAgZm9yIHVzZXJfd3JhcHBlciBpbiB1c2VyX3dyYXBwZXJzLnZhbHVlcygpOgogICAgICAgIHN5bmNfdXNlcih1c2VyX3dyYXBwZXIpCiAgICBsb2dnaW5nLmluZm8oIkVORDogYWlyZmxvdyB1c2VycyBzeW5jIikKCiAgICAjIGVuc3VyZXMgdGhhbiBhbnkgU1FMQWxjaGVteSBzZXNzaW9ucyBhcmUgY2xvc2VkIChzbyB3ZSBkb24ndCBob2xkIGEgY29ubmVjdGlvbiB0byB0aGUgZGF0YWJhc2UpCiAgICBmbGFza19hcHAuZG9fdGVhcmRvd25fYXBwY29udGV4dCgpCgoKZGVmIHN5bmNfd2l0aF9haXJmbG93KCkgLT4gTm9uZToKICAgICIiIgogICAgUHJlZm9ybSBhIHN5bmMgb2YgYWxsIG9iamVjdHMgd2l0aCBhaXJmbG93IChub3RlLCBgc3luY193aXRoX2FpcmZsb3coKWAgaXMgY2FsbGVkIGluIGBtYWluKClgIHRlbXBsYXRlKS4KICAgICIiIgogICAgc3luY19hbGxfdXNlcnModXNlcl93cmFwcGVycz1WQVJfX1VTRVJfV1JBUFBFUlMpCgoKIyMjIyMjIyMjIyMjIyMKIyMgUnVuIE1haW4gIyMKIyMjIyMjIyMjIyMjIyMKbWFpbihzeW5jX2ZvcmV2ZXI9VHJ1ZSk="
+---
+# Source: airflow/templates/config/configmap-pod-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-pod-template
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+data:
+  pod_template.yaml: |-
+    
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: dummy-name
+    spec:
+      restartPolicy: Never
+      serviceAccountName: airflow
+      shareProcessNamespace: false
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      securityContext:
+        fsGroup: 0
+      containers:
+        - name: base      
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:        
+            - secretRef:
+                name: airflow-config-envs
+          env:
+            ## KubernetesExecutor Pods use LocalExecutor internally
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: LocalExecutor        
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "20"
+          ports: []
+          command: []
+          args: []
+          volumeMounts:        
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      volumes:    
+        - name: logs-data
+          emptyDir: {}
+---
+# Source: airflow/templates/rbac/airflow-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airflow
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+  - "list"
+  - "patch"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/log"
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - "create"
+  - "get"
+---
+# Source: airflow/templates/rbac/airflow-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airflow
+  labels:
+    app: airflow
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: airflow
+subjects:
+- kind: ServiceAccount
+  name: airflow
+  namespace: airflow
+---
+# Source: airflow/charts/postgresql/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-postgresql-headless
+  labels:
+    app: postgresql
+    chart: postgresql-8.6.4
+    release: "airflow"
+    heritage: "Helm"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app: postgresql
+    release: "airflow"
+---
+# Source: airflow/charts/postgresql/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-postgresql
+  labels:
+    app: postgresql
+    chart: postgresql-8.6.4
+    release: "airflow"
+    heritage: "Helm"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app: postgresql
+    release: "airflow"
+    role: master
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-pgbouncer
+  labels:
+    app: airflow
+    component: pgbouncer
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app: airflow
+    component: pgbouncer
+    release: airflow
+  ports:
+    - name: pgbouncer
+      protocol: TCP
+      port: 6432
+---
+# Source: airflow/templates/webserver/webserver-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-web
+  labels:
+    app: airflow
+    component: web
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app: airflow
+    component: web
+    release: airflow
+  sessionAffinity: None
+  ports:
+    - name: web
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+# Source: airflow/templates/db-migrations/db-migrations-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-db-migrations
+  labels:
+    app: airflow
+    component: db-migrations
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    ## only 1 replica should run at a time
+    type: Recreate
+  selector:
+    matchLabels:
+      app: airflow
+      component: db-migrations
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/db-migrations-script: 37898f38b90abd06081105d992362ec9e0d0015123b69e758e59031a9e6ddfc9
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: db-migrations
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      securityContext:
+        fsGroup: 0
+      serviceAccountName: airflow
+      initContainers:        
+        - name: check-db  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec timeout 60s airflow db check"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      containers:
+        - name: db-migrations          
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:            
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "python"
+            - "-u"
+            - "/mnt/scripts/db_migrations.py"
+          volumeMounts:            
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+            - name: scripts
+              mountPath: /mnt/scripts
+              readOnly: true
+      volumes:        
+        - name: logs-data
+          emptyDir: {}
+        - name: scripts
+          secret:
+            secretName: airflow-db-migrations
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-pgbouncer
+  labels:
+    app: airflow
+    component: pgbouncer
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      ## multiple pgbouncer pods can safely run concurrently
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: airflow
+      component: pgbouncer
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-pgbouncer: e6271c750a6580256adf79b243badf633c71cbf1da3a0852424bfb8a8ced9675
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: pgbouncer
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      securityContext:
+        fsGroup: 0
+      terminationGracePeriodSeconds: 120
+      serviceAccountName: airflow
+      containers:
+        - name: pgbouncer
+          image: ghcr.io/airflow-helm/pgbouncer:1.18.0-patch.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+          resources:
+            {}
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          ports:
+            - name: pgbouncer
+              containerPort: 6432
+              protocol: TCP
+          command:
+            - "/usr/bin/dumb-init"
+            ## rewrite SIGTERM as SIGINT, so pgbouncer does a safe shutdown
+            - "--rewrite=15:2"
+            - "--"
+          args:
+            - "/bin/sh"
+            - "-c"
+            ## we generate users.txt on startup, because DATABASE_PASSWORD is defined from a Secret,
+            ## and we want to pickup the new values on container restart (possibly due to livenessProbe failure)
+            - |-
+              /home/pgbouncer/config/gen_self_signed_cert.sh && \
+              /home/pgbouncer/config/gen_auth_file.sh && \
+              exec pgbouncer /home/pgbouncer/config/pgbouncer.ini
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 60
+            failureThreshold: 3
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                ## this check is intended to fail when the DATABASE_PASSWORD secret is updated,
+                ## which would cause `gen_auth_file.sh` to run again on container start
+                - psql $(eval $DATABASE_PSQL_CMD) --tuples-only --command="SELECT 1;" | grep -q "1"
+          startupProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 30
+            tcpSocket:
+              port: 6432
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /home/pgbouncer/config
+              readOnly: true
+            - name: pgbouncer-certs
+              mountPath: /home/pgbouncer/certs
+              readOnly: true
+      volumes:
+        - name: pgbouncer-config
+          secret:
+            secretName: airflow-pgbouncer
+            items:
+              - key: gen_auth_file.sh
+                path: gen_auth_file.sh
+                mode: 0755
+              - key: gen_self_signed_cert.sh
+                path: gen_self_signed_cert.sh
+                mode: 0755
+              - key: pgbouncer.ini
+                path: pgbouncer.ini
+        - name: pgbouncer-certs
+          projected:
+            sources:
+---
+# Source: airflow/templates/scheduler/scheduler-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-scheduler
+  labels:
+    app: airflow
+    component: scheduler
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      ## multiple schedulers can run concurrently (Airflow 2.0)
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: airflow
+      component: scheduler
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/config-pod-template: 2e8d42bc94d6c615f1c7231e9c349227a2c12f156caecf72c0965ac07932583c
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: scheduler
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      securityContext:
+        fsGroup: 0
+      serviceAccountName: airflow
+      initContainers:        
+        - name: check-db  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec timeout 60s airflow db check"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs        
+        - name: wait-for-db-migrations  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow db check-migrations -t 60"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      containers:
+        - name: airflow-scheduler          
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:            
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow scheduler -n -1"
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 60
+            exec:
+              command:                
+                - "/usr/bin/dumb-init"
+                - "--"
+                - "/entrypoint"
+                - "python"
+                - "-Wignore"
+                - "-c"
+                - |
+                  import os
+                  import sys
+
+                  # suppress logs triggered from importing airflow packages
+                  os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
+
+                  # shared imports
+                  try:
+                      from airflow.jobs.job import Job
+                  except ImportError:
+                      # `BaseJob` was renamed to `Job` in airflow 2.6.0
+                      from airflow.jobs.base_job import BaseJob as Job
+                  from airflow.utils.db import create_session
+                  from airflow.utils.net import get_hostname
+
+                  # heartbeat check imports
+                  try:
+                      from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+                  except ImportError:
+                      # `SchedulerJob` is wrapped by `SchedulerJobRunner` since airflow 2.6.0
+                      from airflow.jobs.scheduler_job import SchedulerJob as SchedulerJobRunner
+
+                  with create_session() as session:
+                      ########################
+                      # heartbeat check
+                      ########################
+                      # ensure the SchedulerJob with most recent heartbeat for this `hostname` is alive
+                      hostname = get_hostname()
+                      scheduler_job = session \
+                          .query(Job) \
+                          .filter_by(job_type=SchedulerJobRunner.job_type) \
+                          .filter_by(hostname=hostname) \
+                          .order_by(Job.latest_heartbeat.desc()) \
+                          .limit(1) \
+                          .first()
+                      if (scheduler_job is not None) and scheduler_job.is_alive():
+                          pass
+                      else:
+                          sys.exit(f"The SchedulerJob (id={scheduler_job.id}) for hostname '{hostname}' is not alive")
+          volumeMounts:            
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+            - name: pod-template
+              mountPath: /opt/airflow/pod_templates/pod_template.yaml
+              subPath: pod_template.yaml
+              readOnly: true        
+        - name: log-cleanup  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:
+            - name: LOG_PATH
+              value: "/opt/airflow/logs"
+            - name: RETENTION_MINUTES
+              value: "21600"
+            - name: INTERVAL_SECONDS
+              value: "900"    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - |
+              set -euo pipefail
+        
+              # break the infinite loop when we receive SIGINT or SIGTERM
+              trap "exit 0" SIGINT SIGTERM
+        
+              while true; do
+                START_EPOCH=$(date --utc +%s)
+                echo "[$(date --utc +%FT%T.%3N)] deleting log files older than $RETENTION_MINUTES minutes..."
+        
+                # delete all writable files ending in ".log" with modified-time older than $RETENTION_MINUTES
+                # NOTE: `-printf "."` prints a "." for each deleted file, which we count the bytes of with `wc -c`
+                DELETED_COUNT=$(
+                  find "$LOG_PATH" \
+                    -type f \
+                    -name "*.log" \
+                    -mmin +"$RETENTION_MINUTES" \
+                    -writable \
+                    -delete \
+                    -printf "." \
+                  | wc -c
+                )
+        
+                END_EPOCH=$(date --utc +%s)
+                LOOP_DURATION=$((END_EPOCH - START_EPOCH))
+                echo "[$(date --utc +%FT%T.%3N)] deleted $DELETED_COUNT files in $LOOP_DURATION seconds"
+        
+                SECONDS_TO_SLEEP=$((INTERVAL_SECONDS - LOOP_DURATION))
+                if (( SECONDS_TO_SLEEP > 0 )); then
+                  echo "[$(date --utc +%FT%T.%3N)] waiting $SECONDS_TO_SLEEP seconds..."
+                  sleep $SECONDS_TO_SLEEP
+                fi
+              done
+          volumeMounts:
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      volumes:        
+        - name: logs-data
+          emptyDir: {}
+        - name: pod-template
+          configMap:
+            name: airflow-pod-template
+---
+# Source: airflow/templates/sync/sync-users-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-sync-users
+  labels:
+    app: airflow
+    component: sync-users
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    ## only 1 replica should run at a time
+    type: Recreate
+  selector:
+    matchLabels:
+      app: airflow
+      component: sync-users
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/sync-users-script: 08d39f38a4119e738bb6631335c8d7135f986300b8547375511a39948a26b223
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: sync-users
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      securityContext:
+        fsGroup: 0
+      serviceAccountName: airflow
+      initContainers:        
+        - name: check-db  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec timeout 60s airflow db check"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs        
+        - name: wait-for-db-migrations  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow db check-migrations -t 60"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      containers:
+        - name: sync-airflow-users          
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:            
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "python"
+            - "-u"
+            - "/mnt/scripts/sync_users.py"
+          volumeMounts:            
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+            - name: scripts
+              mountPath: /mnt/scripts
+              readOnly: true
+      volumes:        
+        - name: logs-data
+          emptyDir: {}
+        - name: scripts
+          secret:
+            secretName: airflow-sync-users
+---
+# Source: airflow/templates/triggerer/triggerer-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-triggerer
+  labels:
+    app: airflow
+    component: triggerer
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      ## multiple triggerer pods can safely run concurrently
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: airflow
+      component: triggerer
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: triggerer
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      serviceAccountName: airflow
+      securityContext:
+        fsGroup: 0
+      initContainers:        
+        - name: check-db  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec timeout 60s airflow db check"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs        
+        - name: wait-for-db-migrations  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow db check-migrations -t 60"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      containers:
+        - name: airflow-triggerer          
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:            
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow triggerer"
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 60
+            failureThreshold: 5
+            exec:
+              command:                
+                - "/usr/bin/dumb-init"
+                - "--"
+                - "/entrypoint"
+                - "python"
+                - "-Wignore"
+                - "-c"
+                - |
+                  import os
+                  import sys
+
+                  # suppress logs triggered from importing airflow packages
+                  os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
+
+                  # shared imports
+                  try:
+                      from airflow.jobs.job import Job
+                  except ImportError:
+                      # `BaseJob` was renamed to `Job` in airflow 2.6.0
+                      from airflow.jobs.base_job import BaseJob as Job
+                  from airflow.utils.db import create_session
+                  from airflow.utils.net import get_hostname
+
+                  # heartbeat check imports
+                  try:
+                      from airflow.jobs.triggerer_job_runner import TriggererJobRunner
+                  except ImportError:
+                      # `TriggererJob` is wrapped by `TriggererJobRunner` since airflow 2.6.0
+                      from airflow.jobs.triggerer_job import TriggererJob as TriggererJobRunner
+
+                  with create_session() as session:
+                      # ensure the TriggererJob with most recent heartbeat for this `hostname` is alive
+                      hostname = get_hostname()
+                      triggerer_job = session \
+                          .query(Job) \
+                          .filter_by(job_type=TriggererJobRunner.job_type) \
+                          .filter_by(hostname=hostname) \
+                          .order_by(Job.latest_heartbeat.desc()) \
+                          .limit(1) \
+                          .first()
+                      if (triggerer_job is not None) and triggerer_job.is_alive():
+                          pass
+                      else:
+                          sys.exit(f"The TriggererJob (id={triggerer_job.id}) for hostname '{hostname}' is not alive")
+          volumeMounts:            
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      volumes:        
+        - name: logs-data
+          emptyDir: {}
+---
+# Source: airflow/templates/webserver/webserver-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-web
+  labels:
+    app: airflow
+    component: web
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      ## multiple web pods can safely run concurrently
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: airflow
+      component: web
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/config-webserver-config: 9738da91e0615e22362250a9f8410a2bba41f3dc2f6f3dc39b508bd194a1fb72
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: web
+        release: airflow
+    spec:
+      restartPolicy: Always
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      serviceAccountName: airflow
+      securityContext:
+        fsGroup: 0
+      initContainers:        
+        - name: check-db  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec timeout 60s airflow db check"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs        
+        - name: wait-for-db-migrations  
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          envFrom:    
+            - secretRef:
+                name: airflow-config-envs
+          env:    
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:    
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow db check-migrations -t 60"
+          volumeMounts:    
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+      containers:
+        - name: airflow-web          
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          ports:
+            - name: web
+              containerPort: 8080
+              protocol: TCP
+          envFrom:            
+            - secretRef:
+                name: airflow-config-envs
+          env:            
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:            
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow webserver"
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            httpGet:
+              scheme: HTTP
+              path: /health
+              port: web
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            httpGet:
+              scheme: HTTP
+              path: /health
+              port: web
+          volumeMounts:            
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+            - name: webserver-config
+              mountPath: /opt/airflow/webserver_config.py
+              subPath: webserver_config.py
+              readOnly: true
+      volumes:        
+        - name: logs-data
+          emptyDir: {}
+        - name: webserver-config
+          secret:
+            secretName: airflow-webserver-config
+            defaultMode: 0644
+---
+# Source: airflow/charts/postgresql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-postgresql
+  labels:
+    app: postgresql
+    chart: postgresql-8.6.4
+    release: "airflow"
+    heritage: "Helm"
+spec:
+  serviceName: airflow-postgresql-headless
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: postgresql
+      release: "airflow"
+      role: master
+  template:
+    metadata:
+      name: airflow-postgresql
+      labels:
+        app: postgresql
+        chart: postgresql-8.6.4
+        release: "airflow"
+        heritage: "Helm"
+        role: master
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:      
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        # - name: do-something
+        #   image: busybox
+        #   command: ['do', 'something']
+        
+      containers:
+        - name: airflow-postgresql
+          image: ghcr.io/airflow-helm/postgresql-bitnami:11.16-patch.0
+          imagePullPolicy: "IfNotPresent"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: POSTGRES_DB
+              value: "airflow"
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "postgres" -d "airflow" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "postgres" -d "airflow" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+              subPath: 
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "1Gi"
+        storageClassName: directpv-min-io

--- a/deployment/plat-infra-services/airflow/community/web.yaml
+++ b/deployment/plat-infra-services/airflow/community/web.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-web
+  labels:
+    app: airflow
+    component: web
+    chart: airflow-8.7.1
+    release: airflow
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      ## multiple web pods can safely run concurrently
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: airflow
+      component: web
+      release: airflow
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: 4804aefbb403fe7afd8eb8154a2bff7edeb2700f48d7dc3d8f3d4a65dde8c737
+        checksum/secret-local-settings: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/config-webserver-config: 9738da91e0615e22362250a9f8410a2bba41f3dc2f6f3dc39b508bd194a1fb72
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: airflow
+        component: web
+        release: airflow
+    spec:
+      restartPolicy: Always
+      serviceAccountName: airflow
+      securityContext:
+        fsGroup: 0
+      containers:
+        - name: airflow-web
+          image: apache/airflow:2.5.3-python3.8
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 50000
+            runAsGroup: 0
+          resources:
+            {}
+          ports:
+            - name: web
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: airflow-config-envs
+          env:
+            - name: DATABASE_USER
+              value: "postgres"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgresql-password
+            - name: CONNECTION_CHECK_MAX_COUNT
+              value: "0"
+          command:
+            - "/usr/bin/dumb-init"
+            - "--"
+            - "/entrypoint"
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow webserver"
+          # livenessProbe:
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 10
+          #   timeoutSeconds: 5
+          #   failureThreshold: 6
+          #   httpGet:
+          #     scheme: HTTP
+          #     path: /health
+          #     port: web
+          # readinessProbe:
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 10
+          #   timeoutSeconds: 5
+          #   failureThreshold: 6
+          #   httpGet:
+          #     scheme: HTTP
+          #     path: /health
+          #     port: web
+          volumeMounts:
+            - name: logs-data
+              mountPath: /opt/airflow/logs
+            - name: webserver-config
+              mountPath: /opt/airflow/webserver_config.py
+              subPath: webserver_config.py
+              readOnly: true
+      volumes:
+        - name: logs-data
+          emptyDir: {}
+        - name: webserver-config
+          secret:
+            secretName: airflow-webserver-config
+            defaultMode: 0644

--- a/deployment/plat-infra-services/airflow/official/README.md
+++ b/deployment/plat-infra-services/airflow/official/README.md
@@ -1,0 +1,60 @@
+Airflow
+-------
+> a work in progress!
+
+
+### Helm chart
+
+We'll use the official chart
+
+- https://airflow.apache.org/docs/helm-chart/stable/index.html
+- https://www.astronomer.io/events/webinars/airflow-helm-chart/
+
+We'll use the official chart, the community-maintained one looks
+much better:
+- https://github.com/airflow-helm/charts
+
+But it didn't work for us---at least version `8.7.1` of that chart.
+The values file we used was basically identical to their K8s executor
+example, except for the Postgres volume where we specified the DirectPV
+storage class and 1GB storage claim.
+
+
+### Deployment
+
+Manual procedure for now, we'll hook it into Argo CD later.
+
+Get a Nix shell, set your K8s config for the target cluster and cd
+into the Airflow deployment dir
+
+```bash
+$ cd nix
+$ nix shell
+$ export KUBECONFIG=/your/cluster/k8s/config.yaml
+$ cd ../deployment/plat-infra-services/airflow
+```
+
+Add the Helm repo and update the cache
+
+```bash
+$ helm repo add apache-airflow https://airflow.apache.org
+$ helm repo update
+```
+
+Then install the `1.10.0` version of the chart with our config
+
+```bash
+$ kubectl apply -f namespace.yaml
+$ helm install airflow apache-airflow/airflow \
+    --namespace airflow \
+    --version "1.10.0" \
+    --values ./helm-values.yaml
+```
+
+
+### debug
+
+helm template airflow apache-airflow/airflow \
+  --namespace airflow \
+  --version "1.10.0" \
+  --values ./helm-values.yaml > out.yaml

--- a/deployment/plat-infra-services/airflow/official/chart.yaml
+++ b/deployment/plat-infra-services/airflow/official/chart.yaml
@@ -1,0 +1,121 @@
+annotations:
+  artifacthub.io/changes: |
+    - description: Add support for container security context
+      kind: added
+      links:
+      - name: '#31043'
+        url: https://github.com/apache/airflow/pull/31043
+    - description: Validate ``executor`` and ``config.core.executor`` match
+      kind: changed
+      links:
+      - name: '#30693'
+        url: https://github.com/apache/airflow/pull/30693
+    - description: Support ``minAvailable`` property for PodDisruptionBudget
+      kind: changed
+      links:
+      - name: '#30603'
+        url: https://github.com/apache/airflow/pull/30603
+    - description: Add ``volumeMounts`` to dag processor ``waitForMigrations``
+      kind: changed
+      links:
+      - name: '#30990'
+        url: https://github.com/apache/airflow/pull/30990
+    - description: Template extra volumes
+      kind: changed
+      links:
+      - name: '#30773'
+        url: https://github.com/apache/airflow/pull/30773
+    - description: Fix webserver probes timeout and period
+      kind: fixed
+      links:
+      - name: '#30609'
+        url: https://github.com/apache/airflow/pull/30609
+    - description: Add missing ``waitForMigrations`` for workers
+      kind: fixed
+      links:
+      - name: '#31625'
+        url: https://github.com/apache/airflow/pull/31625
+    - description: Add missing ``priorityClassName`` to K8S worker pod template
+      kind: fixed
+      links:
+      - name: '#31328'
+        url: https://github.com/apache/airflow/pull/31328
+    - description: Adding log groomer sidecar to dag processor
+      kind: fixed
+      links:
+      - name: '#30726'
+        url: https://github.com/apache/airflow/pull/30726
+    - description: Do not propagate global security context to statsd and redis
+      kind: fixed
+      links:
+      - name: '#31865'
+        url: https://github.com/apache/airflow/pull/31865
+    - description: 'Misc: Default Airflow version to 2.6.2'
+      kind: changed
+      links:
+      - name: '#31979'
+        url: https://github.com/apache/airflow/pull/31979
+    - description: 'Misc: Use template comments for the chart license header'
+      kind: changed
+      links:
+      - name: '#30569'
+        url: https://github.com/apache/airflow/pull/30569
+    - description: 'Misc: Align ``apiVersion`` and ``kind`` order in chart templates'
+      kind: changed
+      links:
+      - name: '#31850'
+        url: https://github.com/apache/airflow/pull/31850
+    - description: 'Misc: Cleanup Kubernetes < 1.23 support'
+      kind: changed
+      links:
+      - name: '#31847'
+        url: https://github.com/apache/airflow/pull/31847
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://airflow.apache.org/docs/helm-chart/1.8.0/
+  artifacthub.io/screenshots: |
+    - title: DAGs View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/dags.png
+    - title: Datasets View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/datasets.png
+    - title: Grid View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/grid.png
+    - title: Graph View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/graph.png
+    - title: Calendar View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/calendar.png
+    - title: Variable View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/variable_hidden.png
+    - title: Gantt Chart
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/gantt.png
+    - title: Task Duration
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/duration.png
+    - title: Code View
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/code.png
+    - title: Task Instance Context Menu
+      url: https://airflow.apache.org/docs/apache-airflow/2.6.2/_images/context.png
+apiVersion: v2
+appVersion: 2.6.2
+dependencies:
+- condition: postgresql.enabled
+  name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.1.9
+description: The official Helm chart to deploy Apache Airflow, a platform to programmatically
+  author, schedule, and monitor workflows
+home: https://airflow.apache.org/
+icon: https://airflow.apache.org/images/airflow_dark_bg.png
+keywords:
+- apache
+- airflow
+- workflow
+- scheduler
+maintainers:
+- email: dev@airflow.apache.org
+  name: Apache Airflow PMC
+name: airflow
+sources:
+- https://github.com/apache/airflow
+type: application
+version: 1.10.0
+

--- a/deployment/plat-infra-services/airflow/official/helm-default.yaml
+++ b/deployment/plat-infra-services/airflow/official/helm-default.yaml
@@ -1,0 +1,2233 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+# Default values for airflow.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Provide a name to substitute for the full names of resources
+fullnameOverride: ""
+
+# Provide a name to substitute for the name of the chart
+nameOverride: ""
+
+# Max number of old replicasets to retain. Can be overridden by each deployment's revisionHistoryLimit
+revisionHistoryLimit: ~
+
+# User and group of airflow user
+uid: 50000
+gid: 0
+
+# Default security context for airflow (deprecated, use `securityContexts` instead)
+securityContext: {}
+#  runAsUser: 50000
+#  fsGroup: 0
+#  runAsGroup: 0
+
+# Detailed default security context for airflow deployments
+securityContexts:
+  pod: {}
+  containers: {}
+
+# Airflow home directory
+# Used for mount paths
+airflowHome: /opt/airflow
+
+# Default airflow repository -- overridden by all the specific images below
+defaultAirflowRepository: apache/airflow
+
+# Default airflow tag to deploy
+defaultAirflowTag: "2.6.2"
+
+# Default airflow digest. If specified, it takes precedence over tag
+defaultAirflowDigest: ~
+
+# Airflow version (Used to make some decisions based on Airflow Version being deployed)
+airflowVersion: "2.6.2"
+
+# Images
+images:
+  airflow:
+    repository: ~
+    tag: ~
+    # Specifying digest takes precedence over tag.
+    digest: ~
+    pullPolicy: IfNotPresent
+  # To avoid images with user code, you can turn this to 'true' and
+  # all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' containers/jobs
+  # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
+  # to run and wait for DB migrations .
+  useDefaultImageForMigration: false
+  # timeout (in seconds) for airflow-migrations to complete
+  migrationsWaitTimeout: 60
+  pod_template:
+    # Note that `images.pod_template.repository` and `images.pod_template.tag` parameters
+    # can be overridden in `config.kubernetes` section. So for these parameters to have effect
+    # `config.kubernetes.worker_container_repository` and `config.kubernetes.worker_container_tag`
+    # must be not set .
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+  flower:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+  statsd:
+    repository: quay.io/prometheus/statsd-exporter
+    tag: v0.22.8
+    pullPolicy: IfNotPresent
+  redis:
+    repository: redis
+    tag: 7-bullseye
+    pullPolicy: IfNotPresent
+  pgbouncer:
+    repository: apache/airflow
+    tag: airflow-pgbouncer-2023.02.24-1.16.1
+    pullPolicy: IfNotPresent
+  pgbouncerExporter:
+    repository: apache/airflow
+    tag: airflow-pgbouncer-exporter-2023.02.21-0.14.0
+    pullPolicy: IfNotPresent
+  gitSync:
+    repository: registry.k8s.io/git-sync/git-sync
+    tag: v3.6.3
+    pullPolicy: IfNotPresent
+
+# Select certain nodes for airflow pods.
+nodeSelector: {}
+affinity: {}
+tolerations: []
+topologySpreadConstraints: []
+
+# Add common labels to all objects and pods defined in this chart.
+labels: {}
+
+# Ingress configuration
+ingress:
+  # Enable all ingress resources (deprecated - use ingress.web.enabled and ingress.flower.enabled)
+  enabled: ~
+
+  # Configs for the Ingress of the web Service
+  web:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the web Ingress
+    annotations: {}
+
+    # The path for the web Ingress
+    path: "/"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the web Ingress (Deprecated - renamed to `ingress.web.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the web Ingress
+    hosts: []
+    # - name: ""
+    #   # configs for web Ingress TLS
+    #   tls:
+    #     # Enable TLS termination for the web Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the web Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
+    # configs for web Ingress TLS (Deprecated - renamed to `ingress.web.hosts[*].tls`)
+    tls:
+      # Enable TLS termination for the web Ingress
+      enabled: false
+      # the name of a pre-created Secret containing a TLS private key and certificate
+      secretName: ""
+
+    # HTTP paths to add to the web Ingress before the default path
+    precedingPaths: []
+
+    # Http paths to add to the web Ingress after the default path
+    succeedingPaths: []
+
+  # Configs for the Ingress of the flower Service
+  flower:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the flower Ingress
+    annotations: {}
+
+    # The path for the flower Ingress
+    path: "/"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the flower Ingress (Deprecated - renamed to `ingress.flower.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the flower Ingress
+    hosts: []
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the flower Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the flower Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
+    # configs for flower Ingress TLS (Deprecated - renamed to `ingress.flower.hosts[*].tls`)
+    tls:
+      # Enable TLS termination for the flower Ingress
+      enabled: false
+      # the name of a pre-created Secret containing a TLS private key and certificate
+      secretName: ""
+
+# Network policy configuration
+networkPolicies:
+  # Enabled network policies
+  enabled: false
+
+# Extra annotations to apply to all
+# Airflow pods
+airflowPodAnnotations: {}
+
+# Extra annotations to apply to
+# main Airflow configmap
+airflowConfigAnnotations: {}
+
+# `airflow_local_settings` file as a string (can be templated).
+airflowLocalSettings: |-
+  {{- if semverCompare ">=2.2.0" .Values.airflowVersion }}
+  {{- if not (or .Values.webserverSecretKey .Values.webserverSecretKeySecretName) }}
+  from airflow.www.utils import UIAlert
+
+  DASHBOARD_UIALERTS = [
+    UIAlert(
+      'Usage of a dynamic webserver secret key detected. We recommend a static webserver secret key instead.'
+      ' See the <a href='
+      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key">'
+      'Helm Chart Production Guide</a> for more details.',
+      category="warning",
+      roles=["Admin"],
+      html=True,
+    )
+  ]
+  {{- end }}
+  {{- end }}
+
+# Enable RBAC (default on most clusters these days)
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  createSCCRoleBinding: false
+
+# Airflow executor
+# One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
+executor: "CeleryExecutor"
+
+# If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's
+# service account will have access to communicate with the api-server and launch pods.
+# If this is true and using CeleryExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the workers
+# will be able to launch pods.
+allowPodLaunching: true
+
+# Environment variables for all airflow containers
+env: []
+# - name: ""
+#   value: ""
+
+# Volumes for all airflow containers
+volumes: []
+
+# VolumeMounts for all airflow containers
+volumeMounts: []
+
+# Secrets for all airflow containers
+secret: []
+# - envName: ""
+#   secretName: ""
+#   secretKey: ""
+
+# Enables selected built-in secrets that are set via environment variables by default.
+# Those secrets are provided by the Helm Chart secrets by default but in some cases you
+# might want to provide some of those variables with _CMD or _SECRET variable, and you should
+# in this case disable setting of those variables by setting the relevant configuration to false.
+enableBuiltInSecretEnvVars:
+  AIRFLOW__CORE__FERNET_KEY: true
+  # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN: true
+  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: true
+  AIRFLOW_CONN_AIRFLOW_DB: true
+  AIRFLOW__WEBSERVER__SECRET_KEY: true
+  AIRFLOW__CELERY__CELERY_RESULT_BACKEND: true
+  AIRFLOW__CELERY__RESULT_BACKEND: true
+  AIRFLOW__CELERY__BROKER_URL: true
+  AIRFLOW__ELASTICSEARCH__HOST: true
+  AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST: true
+
+# Extra secrets that will be managed by the chart
+# (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
+# The format for secret data is "key/value" where
+#    * key (can be templated) is the name of the secret that will be created
+#    * value: an object with the standard 'data' or 'stringData' key (or both).
+#          The value associated with those keys must be a string (can be templated)
+extraSecrets: {}
+# eg:
+# extraSecrets:
+#   '{{ .Release.Name }}-airflow-connections':
+#     type: 'Opaque'
+#     labels:
+#       my.custom.label/v1: my_custom_label_value_1
+#     data: |
+#       AIRFLOW_CONN_GCP: 'base64_encoded_gcp_conn_string'
+#       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'
+#     stringData: |
+#       AIRFLOW_CONN_OTHER: 'other_conn'
+#   '{{ .Release.Name }}-other-secret-name-suffix':
+#     data: |
+#        ...
+
+# Extra ConfigMaps that will be managed by the chart
+# (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
+# The format for configmap data is "key/value" where
+#    * key (can be templated) is the name of the configmap that will be created
+#    * value: an object with the standard 'data' key.
+#          The value associated with this keys must be a string (can be templated)
+extraConfigMaps: {}
+# eg:
+# extraConfigMaps:
+#   '{{ .Release.Name }}-airflow-variables':
+#     labels:
+#       my.custom.label/v2: my_custom_label_value_2
+#     data: |
+#       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
+#       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
+
+# Extra env 'items' that will be added to the definition of airflow containers
+# a string is expected (can be templated).
+# TODO: difference from `env`? This is a templated string. Probably should template `env` and remove this.
+extraEnv: ~
+# eg:
+# extraEnv: |
+#   - name: AIRFLOW__CORE__LOAD_EXAMPLES
+#     value: 'True'
+
+# Extra envFrom 'items' that will be added to the definition of airflow containers
+# A string is expected (can be templated).
+extraEnvFrom: ~
+# eg:
+# extraEnvFrom: |
+#   - secretRef:
+#       name: '{{ .Release.Name }}-airflow-connections'
+#   - configMapRef:
+#       name: '{{ .Release.Name }}-airflow-variables'
+
+# Airflow database & redis config
+data:
+  # If secret names are provided, use those secrets
+  # These secrets must be created manually, eg:
+  #
+  # kind: Secret
+  # apiVersion: v1
+  # metadata:
+  #   name: custom-airflow-metadata-secret
+  # type: Opaque
+  # data:
+  #   connection: base64_encoded_connection_string
+
+  metadataSecretName: ~
+  # When providing secret names and using the same database for metadata and
+  # result backend, for Airflow < 2.4.0 it is necessary to create a separate
+  # secret for result backend but with a db+ scheme prefix.
+  # For Airflow >= 2.4.0 it is possible to not specify the secret again,
+  # as Airflow will use sql_alchemy_conn with a db+ scheme prefix by default.
+  resultBackendSecretName: ~
+  brokerUrlSecretName: ~
+
+  # Otherwise pass connection values in
+  metadataConnection:
+    user: postgres
+    pass: postgres
+    protocol: postgresql
+    host: ~
+    port: 5432
+    db: postgres
+    sslmode: disable
+  # resultBackendConnection defaults to the same database as metadataConnection
+  resultBackendConnection: ~
+  # or, you can use a different database
+  # resultBackendConnection:
+  #   user: postgres
+  #   pass: postgres
+  #   protocol: postgresql
+  #   host: ~
+  #   port: 5432
+  #   db: postgres
+  #   sslmode: disable
+  # Note: brokerUrl can only be set during install, not upgrade
+  brokerUrl: ~
+
+# Fernet key settings
+# Note: fernetKey can only be set during install, not upgrade
+fernetKey: ~
+fernetKeySecretName: ~
+
+# Flask secret key for Airflow Webserver: `[webserver] secret_key` in airflow.cfg
+webserverSecretKey: ~
+webserverSecretKeySecretName: ~
+
+# In order to use kerberos you need to create secret containing the keytab file
+# The secret name should follow naming convention of the application where resources are
+# name {{ .Release-name }}-<POSTFIX>. In case of the keytab file, the postfix is "kerberos-keytab"
+# So if your release is named "my-release" the name of the secret should be "my-release-kerberos-keytab"
+#
+# The Keytab content should be available in the "kerberos.keytab" key of the secret.
+#
+#  apiVersion: v1
+#  kind: Secret
+#  data:
+#    kerberos.keytab: <base64_encoded keytab file content>
+#  type: Opaque
+#
+#
+#  If you have such keytab file you can do it with similar
+#
+#  kubectl create secret generic {{ .Release.name }}-kerberos-keytab --from-file=kerberos.keytab
+#
+#
+#  Alternatively, instead of manually creating the secret, it is possible to specify
+#  kerberos.keytabBase64Content parameter. This parameter should contain base64 encoded keytab.
+#
+
+kerberos:
+  enabled: false
+  ccacheMountPath: /var/kerberos-ccache
+  ccacheFileName: cache
+  configPath: /etc/krb5.conf
+  keytabBase64Content: ~
+  keytabPath: /etc/airflow.keytab
+  principal: airflow@FOO.COM
+  reinitFrequency: 3600
+  config: |
+    # This is an example config showing how you can use templating and how "example" config
+    # might look like. It works with the test kerberos server that we are using during integration
+    # testing at Apache Airflow (see `scripts/ci/docker-compose/integration-kerberos.yml` but in
+    # order to make it production-ready you must replace it with your own configuration that
+    # Matches your kerberos deployment. Administrators of your Kerberos instance should
+    # provide the right configuration.
+
+    [logging]
+    default = "FILE:{{ template "airflow_logs_no_quote" . }}/kerberos_libs.log"
+    kdc = "FILE:{{ template "airflow_logs_no_quote" . }}/kerberos_kdc.log"
+    admin_server = "FILE:{{ template "airflow_logs_no_quote" . }}/kadmind.log"
+
+    [libdefaults]
+    default_realm = FOO.COM
+    ticket_lifetime = 10h
+    renew_lifetime = 7d
+    forwardable = true
+
+    [realms]
+    FOO.COM = {
+      kdc = kdc-server.foo.com
+      admin_server = admin_server.foo.com
+    }
+
+# Airflow Worker Config
+workers:
+  # Number of airflow celery workers in StatefulSet
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running Airflow workers (templated).
+  command: ~
+  # Args to use when running Airflow workers (templated).
+  args:
+    - "bash"
+    - "-c"
+    # The format below is necessary to get `helm lint` happy
+    - |-
+      exec \
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
+
+  # If the worker stops responding for 5 minutes (5*60s) kill the
+  # worker and let Kubernetes restart it
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+
+  # Update Strategy when worker is deployed as a StatefulSet
+  updateStrategy: ~
+  # Update Strategy when worker is deployed as a Deployment
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for worker deployments for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to worker kubernetes service account.
+    annotations: {}
+
+  # Allow KEDA autoscaling.
+  # Persistence.enabled must be set to false to use KEDA.
+  keda:
+    enabled: false
+    namespaceLabels: {}
+
+    # How often KEDA polls the airflow DB to report new scale requests to the HPA
+    pollingInterval: 5
+
+    # How many seconds KEDA will wait before scaling to zero.
+    # Note that HPA has a separate cooldown period for scale-downs
+    cooldownPeriod: 30
+
+    # Minimum number of workers created by keda
+    minReplicaCount: 0
+
+    # Maximum number of workers created by keda
+    maxReplicaCount: 10
+
+    # Specify HPA related options
+    advanced: {}
+    # horizontalPodAutoscalerConfig:
+    #   behavior:
+    #     scaleDown:
+    #       stabilizationWindowSeconds: 300
+    #       policies:
+    #         - type: Percent
+    #           value: 100
+    #           periodSeconds: 15
+
+  persistence:
+    # Enable persistent volumes
+    enabled: true
+    # Volume size for worker StatefulSet
+    size: 100Gi
+    # If using a custom storageClass, pass name ref to all statefulSets here
+    storageClassName:
+    # Execute init container to chown log directory.
+    # This is currently only needed in kind, due to usage
+    # of local-path provisioner.
+    fixPermissions: false
+    # Annotations to add to worker volumes
+    annotations: {}
+    # Detailed default security context for persistence for container level
+    securityContexts:
+      container: {}
+
+  kerberosSidecar:
+    # Enable kerberos sidecar
+    enabled: false
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # Detailed default security context for kerberosSidecar for container level
+    securityContexts:
+      container: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Grace period for tasks to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 600
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+
+  # Launch additional containers into worker.
+  # Note: If used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main
+  # container finishes so Airflow can continue the worker shutdown process!
+  extraContainers: []
+  # Add additional init containers into workers.
+  extraInitContainers: []
+
+  # Mount additional volumes into worker. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for airflow worker pods.
+  nodeSelector: {}
+  priorityClassName: ~
+  affinity: {}
+  # default worker affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: worker
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
+  tolerations: []
+  topologySpreadConstraints: []
+  # hostAliases to use in worker pods.
+  # See:
+  # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  hostAliases: []
+  # - ip: "127.0.0.2"
+  #   hostnames:
+  #   - "test.hostname.one"
+  # - ip: "127.0.0.3"
+  #   hostnames:
+  #   - "test.hostname.two"
+
+  # annotations for the worker resource
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Labels specific to workers objects and pods
+  labels: {}
+
+  logGroomerSidecar:
+    # Whether to deploy the Airflow worker log groomer sidecar.
+    enabled: true
+    # Command to use when running the Airflow worker log groomer sidecar (templated).
+    command: ~
+    # Args to use when running the Airflow worker log groomer sidecar (templated).
+    args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # Detailed default security context for logGroomerSidecar for container level
+    securityContexts:
+      container: {}
+
+  waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
+    env: []
+    # Detailed default security context for waitForMigrations for container level
+    securityContexts:
+      container: {}
+
+  env: []
+
+# Airflow scheduler settings
+scheduler:
+  #  hostAliases for the scheduler pod
+  hostAliases: []
+  #  - ip: "127.0.0.1"
+  #    hostnames:
+  #      - "foo.local"
+  #  - ip: "10.1.2.3"
+  #    hostnames:
+  #      - "foo.remote"
+
+  # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
+  # scheduler and let Kubernetes restart it
+  livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+  # Airflow 2.0 allows users to run multiple schedulers,
+  # However this feature is only recommended for MySQL 8+ and Postgres
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running the Airflow scheduler (templated).
+  command: ~
+  # Args to use when running the Airflow scheduler (templated).
+  args: ["bash", "-c", "exec airflow scheduler"]
+
+  # Update Strategy when scheduler is deployed as a StatefulSet
+  # (when using LocalExecutor and workers.persistence)
+  updateStrategy: ~
+  # Update Strategy when scheduler is deployed as a Deployment
+  # (when not using LocalExecutor and workers.persistence)
+  strategy: ~
+
+  # When not set, the values defined in the global securityContext will be used
+  # (deprecated, use `securityContexts` instead)
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for scheduler deployments for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to scheduler kubernetes service account.
+    annotations: {}
+
+  # Scheduler pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+
+  # Launch additional containers into scheduler.
+  extraContainers: []
+  # Add additional init containers into scheduler.
+  extraInitContainers: []
+
+  # Mount additional volumes into scheduler. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for airflow scheduler pods.
+  nodeSelector: {}
+  affinity: {}
+  # default scheduler affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: scheduler
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  # annotations for scheduler deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Labels specific to scheduler objects and pods
+  labels: {}
+
+  logGroomerSidecar:
+    # Whether to deploy the Airflow scheduler log groomer sidecar.
+    enabled: true
+    # Command to use when running the Airflow scheduler log groomer sidecar (templated).
+    command: ~
+    # Args to use when running the Airflow scheduler log groomer sidecar (templated).
+    args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # Detailed default security context for logGroomerSidecar for container level
+    securityContexts:
+      container: {}
+
+  waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
+    env: []
+    # Detailed default security context for waitForMigrations for container level
+    securityContexts:
+      container: {}
+
+  env: []
+
+# Airflow create user job settings
+createUserJob:
+  # Limit the lifetime of the job object after it finished execution.
+  ttlSecondsAfterFinished: 300
+  # Command to use when running the create user job (templated).
+  command: ~
+  # Args to use when running the create user job (templated).
+  args:
+    - "bash"
+    - "-c"
+    # The format below is necessary to get `helm lint` happy
+    - |-
+      exec \
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "users create" "create_user" }} "$@"
+    - --
+    - "-r"
+    - "{{ .Values.webserver.defaultUser.role }}"
+    - "-u"
+    - "{{ .Values.webserver.defaultUser.username }}"
+    - "-e"
+    - "{{ .Values.webserver.defaultUser.email }}"
+    - "-f"
+    - "{{ .Values.webserver.defaultUser.firstName }}"
+    - "-l"
+    - "{{ .Values.webserver.defaultUser.lastName }}"
+    - "-p"
+    - "{{ .Values.webserver.defaultUser.password }}"
+
+  # Annotations on the create user job pod
+  annotations: {}
+  # jobAnnotations are annotations on the create user job
+  jobAnnotations: {}
+
+  # Labels specific to createUserJob objects and pods
+  labels: {}
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for createUserJob for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to create user kubernetes service account.
+    annotations: {}
+
+  # Launch additional containers into user creation job
+  extraContainers: []
+
+  # Mount additional volumes into user creation job. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+  # In case you need to disable the helm hooks that create the jobs after install.
+  # Disable this if you are using ArgoCD for example
+  useHelmHooks: true
+  applyCustomEnv: true
+
+  env: []
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Airflow database migration job settings
+migrateDatabaseJob:
+  enabled: true
+  # Limit the lifetime of the job object after it finished execution.
+  ttlSecondsAfterFinished: 300
+  # Command to use when running the migrate database job (templated).
+  command: ~
+  # Args to use when running the migrate database job (templated).
+  args:
+    - "bash"
+    - "-c"
+    # The format below is necessary to get `helm lint` happy
+    - |-
+      exec \
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "db upgrade" "upgradedb" }}
+
+  # Annotations on the database migration pod
+  annotations: {}
+  # jobAnnotations are annotations on the database migration job
+  jobAnnotations: {}
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for migrateDatabaseJob for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to migrate database job kubernetes service account.
+    annotations: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Launch additional containers into database migration job
+  extraContainers: []
+
+  # Mount additional volumes into database migration job. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+  # In case you need to disable the helm hooks that create the jobs after install.
+  # Disable this if you are using ArgoCD for example
+  useHelmHooks: true
+  applyCustomEnv: true
+
+# Airflow webserver settings
+webserver:
+  #  hostAliases for the webserver pod
+  hostAliases: []
+  #  - ip: "127.0.0.1"
+  #    hostnames:
+  #      - "foo.local"
+  #  - ip: "10.1.2.3"
+  #    hostnames:
+  #      - "foo.remote"
+  allowPodLogReading: true
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 5
+    periodSeconds: 10
+    scheme: HTTP
+
+  readinessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 5
+    periodSeconds: 10
+    scheme: HTTP
+
+  # Number of webservers
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running the Airflow webserver (templated).
+  command: ~
+  # Args to use when running the Airflow webserver (templated).
+  args: ["bash", "-c", "exec airflow webserver"]
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to webserver kubernetes service account.
+    annotations: {}
+
+  # Webserver pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
+
+  # Allow overriding Update Strategy for Webserver
+  strategy: ~
+
+  # When not set, the values defined in the global securityContext will be used
+  # (deprecated, use `securityContexts` instead)
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security contexts for webserver deployments for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Additional network policies as needed (Deprecated - renamed to `webserver.networkPolicy.ingress.from`)
+  extraNetworkPolicies: []
+  networkPolicy:
+    ingress:
+      # Peers for webserver NetworkPolicy ingress
+      from: []
+      # Ports for webserver NetworkPolicy ingress (if `from` is set)
+      ports:
+        - port: "{{ .Values.ports.airflowUI }}"
+
+  resources: {}
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
+  # Create initial user.
+  defaultUser:
+    enabled: true
+    role: Admin
+    username: admin
+    email: admin@example.com
+    firstName: admin
+    lastName: user
+    password: admin
+
+  # Launch additional containers into webserver.
+  extraContainers: []
+  # Add additional init containers into webserver.
+  extraInitContainers: []
+
+  # Mount additional volumes into webserver. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # This string (can be templated) will be mounted into the Airflow Webserver
+  # as a custom webserver_config.py. You can bake a webserver_config.py in to
+  # your image instead or specify a configmap containing the
+  # webserver_config.py.
+  webserverConfig: ~
+  # webserverConfig: |
+  #   from airflow import configuration as conf
+
+  #   # The SQLAlchemy connection string.
+  #   SQLALCHEMY_DATABASE_URI = conf.get('database', 'SQL_ALCHEMY_CONN')
+
+  #   # Flask-WTF flag for CSRF
+  #   CSRF_ENABLED = True
+  webserverConfigConfigMapName: ~
+
+  service:
+    type: ClusterIP
+    ## service annotations
+    annotations: {}
+    ports:
+      - name: airflow-ui
+        port: "{{ .Values.ports.airflowUI }}"
+    # To change the port used to access the webserver:
+    # ports:
+    #   - name: airflow-ui
+    #     port: 80
+    #     targetPort: airflow-ui
+    # To only expose a sidecar, not the webserver directly:
+    # ports:
+    #   - name: only_sidecar
+    #     port: 80
+    #     targetPort: 8888
+    # If you have a public IP, set NodePort to set an external port.
+    # Service type must be 'NodePort':
+    # ports:
+    #   - name: airflow-ui
+    #     port: 8080
+    #     targetPort: 8080
+    #     nodePort: 31151
+    loadBalancerIP: ~
+    ## Limit load balancer source ips to list of CIDRs
+    # loadBalancerSourceRanges:
+    #   - "10.123.0.0/16"
+    loadBalancerSourceRanges: []
+
+  # Select certain nodes for airflow webserver pods.
+  nodeSelector: {}
+  priorityClassName: ~
+  affinity: {}
+  # default webserver affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: webserver
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
+  tolerations: []
+  topologySpreadConstraints: []
+
+  # annotations for webserver deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Labels specific webserver app
+  labels: {}
+
+  waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
+    env: []
+    # Detailed default security context for waitForMigrations for container level
+    securityContexts:
+      container: {}
+
+  env: []
+
+# Airflow Triggerer Config
+triggerer:
+  enabled: true
+  # Number of airflow triggerers in the deployment
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running Airflow triggerers (templated).
+  command: ~
+  # Args to use when running Airflow triggerer (templated).
+  args: ["bash", "-c", "exec airflow triggerer"]
+
+  # Update Strategy when triggerer is deployed as a StatefulSet
+  updateStrategy: ~
+  # Update Strategy when triggerer is deployed as a Deployment
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
+
+  # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
+  # triggerer and let Kubernetes restart it
+  livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to triggerer kubernetes service account.
+    annotations: {}
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for triggerer for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+  persistence:
+    # Enable persistent volumes
+    enabled: true
+    # Volume size for triggerer StatefulSet
+    size: 100Gi
+    # If using a custom storageClass, pass name ref to all statefulSets here
+    storageClassName:
+    # Execute init container to chown log directory.
+    # This is currently only needed in kind, due to usage
+    # of local-path provisioner.
+    fixPermissions: false
+    # Annotations to add to triggerer volumes
+    annotations: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Grace period for triggerer to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 60
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+
+  # Launch additional containers into triggerer.
+  extraContainers: []
+  # Add additional init containers into triggerers.
+  extraInitContainers: []
+
+  # Mount additional volumes into triggerer. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for airflow triggerer pods.
+  nodeSelector: {}
+  affinity: {}
+  # default triggerer affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: triggerer
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  # annotations for the triggerer deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Labels specific to triggerer objects and pods
+  labels: {}
+
+  logGroomerSidecar:
+    # Whether to deploy the Airflow triggerer log groomer sidecar.
+    enabled: true
+    # Command to use when running the Airflow triggerer log groomer sidecar (templated).
+    command: ~
+    # Args to use when running the Airflow triggerer log groomer sidecar (templated).
+    args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # Detailed default security context for logGroomerSidecar for container level
+    securityContexts:
+      container: {}
+
+  waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
+    env: []
+    # Detailed default security context for waitForMigrations for container level
+    securityContexts:
+      container: {}
+
+  env: []
+
+# Airflow Dag Processor Config
+dagProcessor:
+  enabled: false
+  # Number of airflow dag processors in the deployment
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running Airflow dag processors (templated).
+  command: ~
+  # Args to use when running Airflow dag processor (templated).
+  args: ["bash", "-c", "exec airflow dag-processor"]
+
+  # Update Strategy for dag processors
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
+
+  # If the dag processor stops heartbeating for 5 minutes (5*60s) kill the
+  # dag processor and let Kubernetes restart it
+  livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to dag processor kubernetes service account.
+    annotations: {}
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for dagProcessor for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Grace period for dag processor to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 60
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+
+  # Launch additional containers into dag processor.
+  extraContainers: []
+  # Add additional init containers into dag processors.
+  extraInitContainers: []
+
+  # Mount additional volumes into dag processor. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for airflow dag processor pods.
+  nodeSelector: {}
+  affinity: {}
+  # default dag processor affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: dag-processor
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  # annotations for the dag processor deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  logGroomerSidecar:
+    # Whether to deploy the Airflow dag processor log groomer sidecar.
+    enabled: true
+    # Command to use when running the Airflow dag processor log groomer sidecar (templated).
+    command: ~
+    # Args to use when running the Airflow dag processor log groomer sidecar (templated).
+    args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  waitForMigrations:
+    # Whether to create init container to wait for db migrations
+    enabled: true
+    env: []
+
+  env: []
+
+# Flower settings
+flower:
+  # Enable flower.
+  # If True, and using CeleryExecutor/CeleryKubernetesExecutor, will deploy flower app.
+  enabled: false
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Command to use when running flower (templated).
+  command: ~
+  # Args to use when running flower (templated).
+  args:
+    - "bash"
+    - "-c"
+    # The format below is necessary to get `helm lint` happy
+    - |-
+      exec \
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery flower" "flower" }}
+
+  # Additional network policies as needed (Deprecated - renamed to `flower.networkPolicy.ingress.from`)
+  extraNetworkPolicies: []
+  networkPolicy:
+    ingress:
+      # Peers for flower NetworkPolicy ingress
+      from: []
+      # Ports for flower NetworkPolicy ingress (if ingressPeers is set)
+      ports:
+        - port: "{{ .Values.ports.flowerUI }}"
+
+  resources: {}
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for flower for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to worker kubernetes service account.
+    annotations: {}
+
+  # A secret containing the connection
+  secretName: ~
+
+  # Else, if username and password are set, create secret from username and password
+  username: ~
+  password: ~
+
+  service:
+    type: ClusterIP
+    ## service annotations
+    annotations: {}
+    ports:
+      - name: flower-ui
+        port: "{{ .Values.ports.flowerUI }}"
+    # To change the port used to access flower:
+    # ports:
+    #   - name: flower-ui
+    #     port: 8080
+    #     targetPort: flower-ui
+    loadBalancerIP: ~
+    ## Limit load balancer source ips to list of CIDRs
+    # loadBalancerSourceRanges:
+    #   - "10.123.0.0/16"
+    loadBalancerSourceRanges: []
+
+  # Launch additional containers into the flower pods.
+  extraContainers: []
+  # Mount additional volumes into the flower pods. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for airflow flower pods.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  # annotations for the flower deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Labels specific to flower objects and pods
+  labels: {}
+  env: []
+
+# StatsD settings
+statsd:
+  enabled: true
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+
+  # Arguments for StatsD exporter command.
+  args: ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
+
+  # Annotations to add to the StatsD Deployment.
+  annotations: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to worker kubernetes service account.
+    annotations: {}
+
+  uid: 65534
+  # When not set, `statsd.uid` will be used
+
+  # (deprecated, use `securityContexts` instead)
+  securityContext: {}
+  #  runAsUser: 65534
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
+  # Detailed default security context for statsd deployments for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  # Additional network policies as needed
+  extraNetworkPolicies: []
+  resources: {}
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
+  service:
+    extraAnnotations: {}
+
+  # Select certain nodes for StatsD pods.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  # Additional mappings for StatsD exporter.
+  # If set, will merge default mapping and extra mappings, default mapping has higher priority.
+  # So, if you want to change some default mapping, please use `overrideMappings`
+  extraMappings: []
+
+  # Override mappings for StatsD exporter.
+  # If set, will ignore setting item in default and `extraMappings`.
+  # So, If you use it, ensure all mapping item contains in it.
+  overrideMappings: []
+
+  podAnnotations: {}
+
+# PgBouncer settings
+pgbouncer:
+  # Enable PgBouncer
+  enabled: false
+  # Number of PgBouncer replicas to run in Deployment
+  replicas: 1
+  # Max number of old replicasets to retain
+  revisionHistoryLimit: ~
+  # Command to use for PgBouncer(templated).
+  command: ["pgbouncer", "-u", "nobody", "/etc/pgbouncer/pgbouncer.ini"]
+  # Args to use for PgBouncer(templated).
+  args: ~
+  auth_type: md5
+  auth_file: /etc/pgbouncer/users.txt
+
+  # annotations to be added to the PgBouncer deployment
+  annotations: {}
+
+  podAnnotations: {}
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to worker kubernetes service account.
+    annotations: {}
+
+  # Additional network policies as needed
+  extraNetworkPolicies: []
+
+  # Pool sizes
+  metadataPoolSize: 10
+  resultBackendPoolSize: 5
+
+  # Maximum clients that can connect to PgBouncer (higher = more file descriptors)
+  maxClientConn: 100
+
+  # supply the name of existing secret with pgbouncer.ini and users.txt defined
+  # you can load them to a k8s secret like the one below
+  #  apiVersion: v1
+  #  kind: Secret
+  #  metadata:
+  #    name: pgbouncer-config-secret
+  #  data:
+  #     pgbouncer.ini: <base64_encoded pgbouncer.ini file content>
+  #     users.txt: <base64_encoded users.txt file content>
+  #  type: Opaque
+  #
+  #  configSecretName: pgbouncer-config-secret
+  #
+  configSecretName: ~
+
+  # PgBouncer pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
+
+  # Limit the resources to PgBouncer.
+  # When you specify the resource request the k8s scheduler uses this information to decide which node to
+  # place the Pod on. When you specify a resource limit for a Container, the kubelet enforces those limits so
+  # that the running container is not allowed to use more of that resource than the limit you set.
+  # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  # Example:
+  #
+  # resource:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+  resources: {}
+
+  service:
+    extraAnnotations: {}
+
+  # https://www.pgbouncer.org/config.html
+  verbose: 0
+  logDisconnections: 0
+  logConnections: 0
+
+  sslmode: "prefer"
+  ciphers: "normal"
+
+  ssl:
+    ca: ~
+    cert: ~
+    key: ~
+
+  # Add extra PgBouncer ini configuration in the databases section:
+  # https://www.pgbouncer.org/config.html#section-databases
+  extraIniMetadata: ~
+  extraIniResultBackend: ~
+  # Add extra general PgBouncer ini configuration: https://www.pgbouncer.org/config.html
+  extraIni: ~
+
+  # Mount additional volumes into pgbouncer. It can be templated like in the following example:
+  #   extraVolumes:
+  #     - name: my-templated-extra-volume
+  #       secret:
+  #          secretName: '{{ include "my_secret_template" . }}'
+  #          defaultMode: 0640
+  #          optional: true
+  #
+  #   extraVolumeMounts:
+  #     - name: my-templated-extra-volume
+  #       mountPath: "{{ .Values.my_custom_path }}"
+  #       readOnly: true
+  extraVolumes: []
+  extraVolumeMounts: []
+
+  # Select certain nodes for PgBouncer pods.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+
+  priorityClassName: ~
+
+  uid: 65534
+
+  # Detailed default security context for pgbouncer for container level
+  securityContexts:
+    container: {}
+
+  metricsExporterSidecar:
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    sslmode: "disable"
+
+    # Detailed default security context for metricsExporterSidecar for container level
+    securityContexts:
+      container: {}
+
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 1
+
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 1
+
+# Configuration for the redis provisioned by the chart
+redis:
+  enabled: true
+  terminationGracePeriodSeconds: 600
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to worker kubernetes service account.
+    annotations: {}
+
+  persistence:
+    # Enable persistent volumes
+    enabled: true
+    # Volume size for worker StatefulSet
+    size: 1Gi
+    # If using a custom storageClass, pass name ref to all statefulSets here
+    storageClassName:
+    # Annotations to add to redis volumes
+    annotations: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # If set use as redis secret. Make sure to also set data.brokerUrlSecretName value.
+  passwordSecretName: ~
+
+  # Else, if password is set, create secret with it,
+  # Otherwise a new password will be generated on install
+  # Note: password can only be set during install, not upgrade.
+  password: ~
+
+  # This setting tells kubernetes that its ok to evict
+  # when it wants to scale a node down.
+  safeToEvict: true
+
+  # Select certain nodes for redis pods.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+
+  # Set to 0 for backwards-compatiblity
+  uid: 0
+  # If not set, `redis.uid` will be used
+  securityContext: {}
+  #  runAsUser: 999
+  #  runAsGroup: 0
+
+  # Detailed default security context for redis for container and pod level
+  securityContexts:
+    pod: {}
+    container: {}
+
+  podAnnotations: {}
+# Auth secret for a private registry
+# This is used if pulling airflow images from a private registry
+registry:
+  secretName: ~
+
+  # Example:
+  # connection:
+  #   user: ~
+  #   pass: ~
+  #   host: ~
+  #   email: ~
+  connection: {}
+
+# Elasticsearch logging configuration
+elasticsearch:
+  # Enable elasticsearch task logging
+  enabled: false
+  # A secret containing the connection
+  secretName: ~
+  # Or an object representing the connection
+  # Example:
+  # connection:
+  #   user: ~
+  #   pass: ~
+  #   host: ~
+  #   port: ~
+  connection: {}
+
+# All ports used by chart
+ports:
+  flowerUI: 5555
+  airflowUI: 8080
+  workerLogs: 8793
+  triggererLogs: 8794
+  redisDB: 6379
+  statsdIngest: 9125
+  statsdScrape: 9102
+  pgbouncer: 6543
+  pgbouncerScrape: 9127
+
+# Define any ResourceQuotas for namespace
+quotas: {}
+
+# Define default/max/min values for pods and containers in namespace
+limits: []
+
+# This runs as a CronJob to cleanup old pods.
+cleanup:
+  enabled: false
+  # Run every 15 minutes
+  schedule: "*/15 * * * *"
+  # Command to use when running the cleanup cronjob (templated).
+  command: ~
+  # Args to use when running the cleanup cronjob (templated).
+  args: ["bash", "-c", "exec airflow kubernetes cleanup-pods --namespace={{ .Release.Namespace }}"]
+
+  # jobAnnotations are annotations on the cleanup CronJob
+  jobAnnotations: {}
+
+  # Select certain nodes for airflow cleanup pods.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  topologySpreadConstraints: []
+
+  podAnnotations: {}
+
+  # Labels specific to cleanup objects and pods
+  labels: {}
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Create ServiceAccount
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the release name
+    name: ~
+
+    # Annotations to add to cleanup cronjob kubernetes service account.
+    annotations: {}
+
+  # When not set, the values defined in the global securityContext will be used
+  securityContext: {}
+  #  runAsUser: 50000
+  #  runAsGroup: 0
+  env: []
+
+  # Detailed default security context for cleanup for container level
+  securityContexts:
+    container: {}
+
+  # Specify history limit
+  # When set, overwrite the default k8s number of successful and failed CronJob executions that are saved.
+  failedJobsHistoryLimit: ~
+  successfulJobsHistoryLimit: ~
+
+# Configuration for postgresql subchart
+# Not recommended for production
+postgresql:
+  enabled: true
+  image:
+    tag: "11"
+  auth:
+    enablePostgresUser: true
+    postgresPassword: postgres
+    username: ""
+    password: ""
+
+# Config settings to go into the mounted airflow.cfg
+#
+# Please note that these values are passed through the `tpl` function, so are
+# all subject to being rendered as go templates. If you need to include a
+# literal `{{` in a value, it must be expressed like this:
+#
+#    a: '{{ "{{ not a template }}" }}'
+#
+# Do not set config containing secrets via plain text values, use Env Var or k8s secret object
+# yamllint disable rule:line-length
+config:
+  core:
+    dags_folder: '{{ include "airflow_dags" . }}'
+    # This is ignored when used with the official Docker image
+    load_examples: 'False'
+    executor: '{{ .Values.executor }}'
+    # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
+    colored_console_log: 'False'
+    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+  logging:
+    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+    colored_console_log: 'False'
+  metrics:
+    statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
+    statsd_port: 9125
+    statsd_prefix: airflow
+    statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
+  webserver:
+    enable_proxy_fix: 'True'
+    # For Airflow 1.10
+    rbac: 'True'
+  celery:
+    flower_url_prefix: '{{ .Values.ingress.flower.path }}'
+    worker_concurrency: 16
+  scheduler:
+    standalone_dag_processor: '{{ ternary "True" "False" .Values.dagProcessor.enabled }}'
+    # statsd params included for Airflow 1.10 backward compatibility; moved to [metrics] in 2.0
+    statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
+    statsd_port: 9125
+    statsd_prefix: airflow
+    statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
+    # `run_duration` included for Airflow 1.10 backward compatibility; removed in 2.0.
+    run_duration: 41460
+  elasticsearch:
+    json_format: 'True'
+    log_id_template: "{dag_id}_{task_id}_{execution_date}_{try_number}"
+  elasticsearch_configs:
+    max_retries: 3
+    timeout: 30
+    retry_timeout: 'True'
+  kerberos:
+    keytab: '{{ .Values.kerberos.keytabPath }}'
+    reinit_frequency: '{{ .Values.kerberos.reinitFrequency }}'
+    principal: '{{ .Values.kerberos.principal }}'
+    ccache: '{{ .Values.kerberos.ccacheMountPath }}/{{ .Values.kerberos.ccacheFileName }}'
+  celery_kubernetes_executor:
+    kubernetes_queue: 'kubernetes'
+  # The `kubernetes` section is deprecated in Airflow >= 2.5.0 due to an airflow.cfg schema change.
+  # The `kubernetes` section can be removed once the helm chart no longer supports Airflow < 2.5.0.
+  kubernetes:
+    namespace: '{{ .Release.Namespace }}'
+    # The following `airflow_` entries are for Airflow 1, and can be removed when it is no longer supported.
+    airflow_configmap: '{{ include "airflow_config" . }}'
+    airflow_local_settings_configmap: '{{ include "airflow_config" . }}'
+    pod_template_file: '{{ include "airflow_pod_template_file" . }}/pod_template_file.yaml'
+    worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
+    worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
+    multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
+  # The `kubernetes_executor` section duplicates the `kubernetes` section in Airflow >= 2.5.0 due to an airflow.cfg schema change.
+  kubernetes_executor:
+    namespace: '{{ .Release.Namespace }}'
+    pod_template_file: '{{ include "airflow_pod_template_file" . }}/pod_template_file.yaml'
+    worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
+    worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
+    multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
+# yamllint enable rule:line-length
+
+# Whether Airflow can launch workers and/or pods in multiple namespaces
+# If true, it creates ClusterRole/ClusterRolebinding (with access to entire cluster)
+multiNamespaceMode: false
+
+# `podTemplate` is a templated string containing the contents of `pod_template_file.yaml` used for
+# KubernetesExecutor workers. The default `podTemplate` will use normal `workers` configuration parameters
+# (e.g. `workers.resources`). As such, you normally won't need to override this directly, however,
+# you can still provide a completely custom `pod_template_file.yaml` if desired.
+# If not set, a default one is created using `files/pod-template-file.kubernetes-helm-yaml`.
+podTemplate: ~
+# The following example is NOT functional, but meant to be illustrative of how you can provide a custom
+# `pod_template_file`. You're better off starting with the default in
+# `files/pod-template-file.kubernetes-helm-yaml` and modifying from there.
+# We will set `priorityClassName` in this example:
+# podTemplate: |
+#   apiVersion: v1
+#   kind: Pod
+#   metadata:
+#     name: placeholder-name
+#     labels:
+#       tier: airflow
+#       component: worker
+#       release: {{ .Release.Name }}
+#   spec:
+#     priorityClassName: high-priority
+#     containers:
+#       - name: base
+#         ...
+
+# Git sync
+dags:
+  persistence:
+    # Annotations for dags PVC
+    annotations: {}
+    # Enable persistent volume for storing dags
+    enabled: false
+    # Volume size for dags
+    size: 1Gi
+    # If using a custom storageClass, pass name here
+    storageClassName:
+    # access mode of the persistent volume
+    accessMode: ReadWriteOnce
+    ## the name of an existing PVC to use
+    existingClaim:
+    ## optional subpath for dag volume mount
+    subPath: ~
+  gitSync:
+    enabled: false
+
+    # git repo clone url
+    # ssh example: git@github.com:apache/airflow.git
+    # https example: https://github.com/apache/airflow.git
+    repo: https://github.com/apache/airflow.git
+    branch: v2-2-stable
+    rev: HEAD
+    depth: 1
+    # the number of consecutive failures allowed before aborting
+    maxFailures: 0
+    # subpath within the repo where dags are located
+    # should be "" if dags are at repo root
+    subPath: "tests/dags"
+    # if your repo needs a user name password
+    # you can load them to a k8s secret like the one below
+    #   ---
+    #   apiVersion: v1
+    #   kind: Secret
+    #   metadata:
+    #     name: git-credentials
+    #   data:
+    #     GIT_SYNC_USERNAME: <base64_encoded_git_username>
+    #     GIT_SYNC_PASSWORD: <base64_encoded_git_password>
+    # and specify the name of the secret below
+    #
+    # credentialsSecret: git-credentials
+    #
+    #
+    # If you are using an ssh clone url, you can load
+    # the ssh private key to a k8s secret like the one below
+    #   ---
+    #   apiVersion: v1
+    #   kind: Secret
+    #   metadata:
+    #     name: airflow-ssh-secret
+    #   data:
+    #     # key needs to be gitSshKey
+    #     gitSshKey: <base64_encoded_data>
+    # and specify the name of the secret below
+    # sshKeySecret: airflow-ssh-secret
+    #
+    # If you are using an ssh private key, you can additionally
+    # specify the content of your known_hosts file, example:
+    #
+    # knownHosts: |
+    #    <host1>,<ip1> <key1>
+    #    <host2>,<ip2> <key2>
+
+    # interval between git sync attempts in seconds
+    # high values are more likely to cause DAGs to become out of sync between different components
+    # low values cause more traffic to the remote git repository
+    wait: 5
+    containerName: git-sync
+    uid: 65533
+
+    # When not set, the values defined in the global securityContext will be used
+    securityContext: {}
+    #  runAsUser: 65533
+    #  runAsGroup: 0
+
+    securityContexts:
+      container: {}
+
+    # Mount additional volumes into git-sync. It can be templated like in the following example:
+    #   extraVolumeMounts:
+    #     - name: my-templated-extra-volume
+    #       mountPath: "{{ .Values.my_custom_path }}"
+    #       readOnly: true
+    extraVolumeMounts: []
+    env: []
+    # Supported env vars for gitsync can be found at https://github.com/kubernetes/git-sync
+    # - name: ""
+    #   value: ""
+
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+logs:
+  persistence:
+    # Enable persistent volume for storing logs
+    enabled: false
+    # Volume size for logs
+    size: 100Gi
+    # Annotations for the logs PVC
+    annotations: {}
+    # If using a custom storageClass, pass name here
+    storageClassName:
+    ## the name of an existing PVC to use
+    existingClaim:

--- a/deployment/plat-infra-services/airflow/official/helm-values.yaml
+++ b/deployment/plat-infra-services/airflow/official/helm-values.yaml
@@ -1,0 +1,29 @@
+dags:
+  persistence:
+    storageClassName: directpv-min-io
+    size: 1Gi
+
+logs:
+  persistence:
+    storageClassName: directpv-min-io
+    size: 1Gi
+
+workers:
+  persistence:
+    storageClassName: directpv-min-io
+    size: 1Gi
+
+triggerer:
+  persistence:
+    storageClassName: directpv-min-io
+    size: 1Gi
+
+redis:
+  persistence:
+    storageClassName: directpv-min-io
+    size: 1Gi
+
+postgresql:
+  primary:
+    persistence:
+      storageClass: directpv-min-io

--- a/deployment/plat-infra-services/airflow/official/namespace.yaml
+++ b/deployment/plat-infra-services/airflow/official/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airflow

--- a/deployment/plat-infra-services/airflow/official/out.yaml
+++ b/deployment/plat-infra-services/airflow/official/out.yaml
@@ -1,0 +1,2459 @@
+---
+# Source: airflow/templates/jobs/create-user-job-serviceaccount.yaml
+###########################################
+## Airflow Create User Job ServiceAccount
+###########################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-create-user-job
+  labels:
+    tier: airflow
+    component: create-user-job
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/jobs/migrate-database-job-serviceaccount.yaml
+#############################################
+## Airflow Migrate Database Job ServiceAccount
+##############################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-migrate-database-job
+  labels:
+    tier: airflow
+    component: run-airflow-migrations
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/redis/redis-serviceaccount.yaml
+######################################
+## Airflow Redis ServiceAccount
+######################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-redis
+  labels:
+    tier: airflow
+    component: redis
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/scheduler/scheduler-serviceaccount.yaml
+################################
+## Airflow Scheduler ServiceAccount
+#################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-scheduler
+  labels:
+    tier: airflow
+    component: scheduler
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/statsd/statsd-serviceaccount.yaml
+######################################
+## Airflow StatsD ServiceAccount
+######################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-statsd
+  labels:
+    tier: airflow
+    component: statsd
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/triggerer/triggerer-serviceaccount.yaml
+################################
+## Airflow Triggerer ServiceAccount
+#################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-triggerer
+  labels:
+    tier: airflow
+    component: triggerer
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/webserver/webserver-serviceaccount.yaml
+######################################
+## Airflow Webserver ServiceAccount
+######################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-webserver
+  labels:
+    tier: airflow
+    component: webserver
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/templates/workers/worker-serviceaccount.yaml
+################################
+## Airflow Worker ServiceAccount
+#################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-worker
+  labels:
+    tier: airflow
+    component: worker
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+---
+# Source: airflow/charts/postgresql/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-postgresql
+  namespace: "airflow"
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  postgres-password: "cG9zdGdyZXM="
+  # We don't auto-generate LDAP password when it's not provided as we do for other passwords
+---
+# Source: airflow/templates/secrets/metadata-connection-secret.yaml
+################################
+## Airflow Metadata Secret
+#################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-airflow-metadata
+  labels:
+    tier: airflow
+    release: airflow
+    chart: airflow
+    heritage: Helm
+type: Opaque
+data:
+  connection: "cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQGFpcmZsb3ctcG9zdGdyZXNxbC5haXJmbG93OjU0MzIvcG9zdGdyZXM/c3NsbW9kZT1kaXNhYmxl"
+---
+# Source: airflow/templates/secrets/webserver-secret-key-secret.yaml
+############################################
+## Airflow Webserver Flask Secret Key Secret
+############################################
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-webserver-secret-key
+  labels:
+    tier: airflow
+    component: webserver
+    release: airflow
+    chart: airflow
+    heritage: Helm
+type: Opaque
+data:
+  webserver-secret-key: "WnpoclZuQnZiazVEWVRKQmFVTkJjblYyVVVWaVNWcEpNRmh4U21zeWRuWT0="
+---
+# Source: airflow/templates/configmaps/configmap.yaml
+################################
+## Airflow ConfigMap
+#################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-airflow-config
+  labels:
+    tier: airflow
+    component: config
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+data:
+  # These are system-specified config overrides.
+  airflow.cfg: |-
+    [celery]
+    flower_url_prefix = /
+    worker_concurrency = 16
+    
+    [celery_kubernetes_executor]
+    kubernetes_queue = kubernetes
+    
+    [core]
+    colored_console_log = False
+    dags_folder = /opt/airflow/dags
+    executor = CeleryExecutor
+    load_examples = False
+    remote_logging = False
+    
+    [elasticsearch]
+    json_format = True
+    log_id_template = {dag_id}_{task_id}_{execution_date}_{try_number}
+    
+    [elasticsearch_configs]
+    max_retries = 3
+    retry_timeout = True
+    timeout = 30
+    
+    [kerberos]
+    ccache = /var/kerberos-ccache/cache
+    keytab = /etc/airflow.keytab
+    principal = airflow@FOO.COM
+    reinit_frequency = 3600
+    
+    [kubernetes]
+    airflow_configmap = airflow-airflow-config
+    airflow_local_settings_configmap = airflow-airflow-config
+    multi_namespace_mode = False
+    namespace = airflow
+    pod_template_file = /opt/airflow/pod_templates/pod_template_file.yaml
+    worker_container_repository = apache/airflow
+    worker_container_tag = 2.6.2
+    
+    [kubernetes_executor]
+    multi_namespace_mode = False
+    namespace = airflow
+    pod_template_file = /opt/airflow/pod_templates/pod_template_file.yaml
+    worker_container_repository = apache/airflow
+    worker_container_tag = 2.6.2
+    
+    [logging]
+    colored_console_log = False
+    remote_logging = False
+    
+    [metrics]
+    statsd_host = airflow-statsd
+    statsd_on = True
+    statsd_port = 9125
+    statsd_prefix = airflow
+    
+    [scheduler]
+    run_duration = 41460
+    standalone_dag_processor = False
+    statsd_host = airflow-statsd
+    statsd_on = True
+    statsd_port = 9125
+    statsd_prefix = airflow
+    
+    [webserver]
+    enable_proxy_fix = True
+    rbac = True
+    
+  airflow_local_settings.py: |-
+    
+    from airflow.www.utils import UIAlert
+    
+    DASHBOARD_UIALERTS = [
+      UIAlert(
+        'Usage of a dynamic webserver secret key detected. We recommend a static webserver secret key instead.'
+        ' See the <a href='
+        '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key">'
+        'Helm Chart Production Guide</a> for more details.',
+        category="warning",
+        roles=["Admin"],
+        html=True,
+      )
+    ]
+---
+# Source: airflow/templates/configmaps/statsd-configmap.yaml
+################################
+## Airflow StatsD ConfigMap
+#################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-statsd
+  labels:
+    tier: airflow
+    component: config
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+data:
+  mappings.yml: |-
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    ---
+    mappings:
+      # Map dot separated stats to labels
+      - match: airflow.dagrun.dependency-check.*.*
+        name: "airflow_dagrun_dependency_check"
+        labels:
+          dag_id: "$1"
+    
+      - match: airflow.operator_successes_(.*)
+        match_type: regex
+        name: "airflow_operator_successes"
+        labels:
+          operator: "$1"
+    
+      - match: airflow.operator_failures_(.*)
+        match_type: regex
+        name: "airflow_operator_failures"
+        labels:
+          operator: "$1"
+    
+      - match: airflow.scheduler_heartbeat
+        match_type: regex
+        name: "airflow_scheduler_heartbeat"
+        labels:
+          type: counter
+    
+      - match: airflow.dag.*.*.duration
+        name: "airflow_task_duration"
+        labels:
+          dag_id: "$1"
+          task_id: "$2"
+    
+      - match: airflow.dagrun.duration.success.*
+        name: "airflow_dagrun_duration"
+        labels:
+          dag_id: "$1"
+    
+      - match: airflow.dagrun.duration.failed.*
+        name: "airflow_dagrun_failed"
+        labels:
+          dag_id: "$1"
+    
+      - match: airflow.dagrun.schedule_delay.*
+        name: "airflow_dagrun_schedule_delay"
+        labels:
+          dag_id: "$1"
+    
+      - match: airflow.dag_processing.last_runtime.*
+        name: "airflow_dag_processing_last_runtime"
+        labels:
+          dag_file: "$1"
+    
+      - match: airflow.dag_processing.last_run.seconds_ago.*
+        name: "airflow_dag_processing_last_run_seconds_ago"
+        labels:
+          dag_file: "$1"
+    
+      - match: airflow.pool.open_slots.*
+        name: "airflow_pool_open_slots"
+        labels:
+          pool: "$1"
+    
+      - match: airflow.pool.used_slots.*
+        name: "airflow_pool_used_slots"
+        labels:
+          pool: "$1"
+    
+      - match: airflow.pool.starving_tasks.*
+        name: "airflow_pool_starving_tasks"
+        labels:
+          pool: "$1"
+---
+# Source: airflow/templates/rbac/pod-launcher-role.yaml
+################################
+## Airflow Pod Launcher Role
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airflow-pod-launcher-role
+  namespace: "airflow"
+  labels:
+    tier: airflow
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "create"
+      - "list"
+      - "get"
+      - "patch"
+      - "watch"
+      - "delete"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/exec"
+    verbs:
+      - "create"
+      - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+---
+# Source: airflow/templates/rbac/pod-log-reader-role.yaml
+################################
+## Airflow Pod Reader Role
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airflow-pod-log-reader-role
+  namespace: "airflow"
+  labels:
+    tier: airflow
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "get"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+      - "list"
+---
+# Source: airflow/templates/rbac/pod-launcher-rolebinding.yaml
+################################
+## Airflow Pod Launcher Role Binding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: "airflow"
+  name: airflow-pod-launcher-rolebinding
+  labels:
+    tier: airflow
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: airflow-pod-launcher-role
+subjects:
+  - kind: ServiceAccount
+    name: airflow-worker
+    namespace: "airflow"
+---
+# Source: airflow/templates/rbac/pod-log-reader-rolebinding.yaml
+################################
+## Airflow Pod Reader Role Binding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: "airflow"
+  name: airflow-pod-log-reader-rolebinding
+  labels:
+    tier: airflow
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: airflow-pod-log-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: airflow-webserver
+    namespace: "airflow"
+  - kind: ServiceAccount
+    name: airflow-triggerer
+    namespace: "airflow"
+---
+# Source: airflow/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-postgresql-hl
+  namespace: "airflow"
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/component: primary
+---
+# Source: airflow/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-postgresql
+  namespace: "airflow"
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/component: primary
+---
+# Source: airflow/templates/redis/redis-service.yaml
+################################
+## Airflow Redis Service
+#################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-redis
+  labels:
+    tier: airflow
+    component: redis
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  type: ClusterIP
+  selector:
+    tier: airflow
+    component: redis
+    release: airflow
+  ports:
+    - name: redis-db
+      protocol: TCP
+      port: 6379
+      targetPort: 6379
+---
+# Source: airflow/templates/statsd/statsd-service.yaml
+################################
+## Airflow StatsD Service
+#################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-statsd
+  labels:
+    tier: airflow
+    component: statsd
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9102"
+spec:
+  type: ClusterIP
+  selector:
+    tier: airflow
+    component: statsd
+    release: airflow
+  ports:
+    - name: statsd-ingest
+      protocol: UDP
+      port: 9125
+      targetPort: 9125
+    - name: statsd-scrape
+      protocol: TCP
+      port: 9102
+      targetPort: 9102
+---
+# Source: airflow/templates/triggerer/triggerer-service.yaml
+################################
+## Airflow triggerer Service
+#################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-triggerer
+  labels:
+    tier: airflow
+    component: triggerer
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  clusterIP: None
+  selector:
+    tier: airflow
+    component: triggerer
+    release: airflow
+  ports:
+    - name: triggerer-logs
+      protocol: TCP
+      port: 8794
+      targetPort: 8794
+---
+# Source: airflow/templates/webserver/webserver-service.yaml
+################################
+## Airflow Webserver Service
+#################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver
+  labels:
+    tier: airflow
+    component: webserver
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  type: ClusterIP
+  selector:
+    tier: airflow
+    component: webserver
+    release: airflow
+  ports:
+    - name: airflow-ui
+      port: 8080
+---
+# Source: airflow/templates/workers/worker-service.yaml
+################################
+## Airflow Worker Service
+#################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-worker
+  labels:
+    tier: airflow
+    component: worker
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  clusterIP: None
+  selector:
+    tier: airflow
+    component: worker
+    release: airflow
+  ports:
+    - name: worker-logs
+      protocol: TCP
+      port: 8793
+      targetPort: 8793
+---
+# Source: airflow/templates/scheduler/scheduler-deployment.yaml
+################################
+## Airflow Scheduler Deployment/StatefulSet
+#################################
+
+# Are we using a local executor?
+# Is persistence enabled on the _workers_?
+# This is important because in $local mode, the scheduler assumes the role of the worker
+# If we're using a StatefulSet
+# We can skip DAGs mounts on scheduler if dagProcessor is enabled, except with $local mode
+# If we're using elasticsearch logging
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-scheduler
+  labels:
+    tier: airflow
+    component: scheduler
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+    executor: CeleryExecutor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: airflow
+      component: scheduler
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: scheduler
+        release: airflow
+      annotations:
+        checksum/metadata-secret: cd6de1cad5366c38201917e3ed1ac78bec2655c819758d1fa68bbe0b6539968b
+        checksum/result-backend-secret: 98a68f230007cfa8f5d3792e1aff843a76b0686409e4a46ab2f092f6865a1b71
+        checksum/pgbouncer-config-secret: 1dae2adc757473469686d37449d076b0c82404f61413b58ae68b3c5e99527688
+        checksum/airflow-config: cb518829e5fe9057b74ba440d7b440acd1fdb57ee3678787d4eac59009ef70b5
+        checksum/extra-configmaps: e862ea47e13e634cf17d476323784fa27dac20015550c230953b526182f5cac8
+        checksum/extra-secrets: e9582fdd622296c976cbc10a5ba7d6702c28a24fe80795ea5b84ba443a56c827
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: airflow-scheduler
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      initContainers:
+        - name: wait-for-airflow-migrations
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          args:          
+            - airflow
+            - db
+            - check-migrations
+            - --migration-wait-timeout=60
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+      containers:
+        # Always run the main scheduler container.
+        - name: scheduler
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - bash
+            - -c
+            - exec airflow scheduler
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection          
+          livenessProbe:
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
+            periodSeconds: 60
+            exec:
+              command:              
+                - sh
+                - -c
+                - |
+                  CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+                  airflow jobs check --job-type SchedulerJob --local
+          resources:
+            {}
+          volumeMounts:
+            - name: config
+              mountPath: /opt/airflow/pod_templates/pod_template_file.yaml
+              subPath: pod_template_file.yaml
+              readOnly: true
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+        - name: scheduler-log-groomer
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - bash
+            - /clean-logs
+          env:
+            - name: AIRFLOW__LOG_RETENTION_DAYS
+              value: "15"
+          volumeMounts:
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config
+        - name: logs
+          emptyDir: {}
+---
+# Source: airflow/templates/statsd/statsd-deployment.yaml
+################################
+## Airflow StatsD Deployment
+#################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-statsd
+  labels:
+    tier: airflow
+    component: statsd
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: airflow
+      component: statsd
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: statsd
+        release: airflow
+    spec:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      serviceAccountName: airflow-statsd
+      securityContext: 
+        runAsUser: 65534
+      restartPolicy: Always
+      containers:
+        - name: statsd
+          image: quay.io/prometheus/statsd-exporter:v0.22.8
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - --statsd.mapping-config=/etc/statsd-exporter/mappings.yml
+          resources:
+            {}
+          ports:
+            - name: statsd-ingest
+              protocol: UDP
+              containerPort: 9125
+            - name: statsd-scrape
+              containerPort: 9102
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9102
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9102
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/statsd-exporter/mappings.yml
+              subPath: mappings.yml
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-statsd
+---
+# Source: airflow/templates/webserver/webserver-deployment.yaml
+################################
+## Airflow Webserver Deployment
+#################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-webserver
+  labels:
+    tier: airflow
+    component: webserver
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  replicas: 1
+  strategy:
+    # Here we define the rolling update strategy
+    # - maxSurge define how many pod we can add at a time
+    # - maxUnavailable define how many pod can be unavailable
+    #   during the rolling update
+    # Setting maxUnavailable to 0 would make sure we have the appropriate
+    # capacity during the rolling update.
+    # You can also use percentage based value instead of integer.
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      tier: airflow
+      component: webserver
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: webserver
+        release: airflow
+      annotations:
+        checksum/metadata-secret: cd6de1cad5366c38201917e3ed1ac78bec2655c819758d1fa68bbe0b6539968b
+        checksum/pgbouncer-config-secret: 1dae2adc757473469686d37449d076b0c82404f61413b58ae68b3c5e99527688
+        checksum/webserver-secret-key: 175a39db68b605149175b7956f2d55c518e554a02ad56235e4341039874bcfc8
+        checksum/airflow-config: cb518829e5fe9057b74ba440d7b440acd1fdb57ee3678787d4eac59009ef70b5
+        checksum/webserver-config: 2f3fdfd294a37094d2abee43b2b09888a5c195ee03414996bf99a4681658af94
+        checksum/extra-configmaps: e862ea47e13e634cf17d476323784fa27dac20015550c230953b526182f5cac8
+        checksum/extra-secrets: e9582fdd622296c976cbc10a5ba7d6702c28a24fe80795ea5b84ba443a56c827
+    spec:
+      serviceAccountName: airflow-webserver
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: webserver
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      restartPolicy: Always
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      initContainers:
+        - name: wait-for-airflow-migrations
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          args:          
+            - airflow
+            - db
+            - check-migrations
+            - --migration-wait-timeout=60
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+      containers:
+        - name: webserver
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - bash
+            - -c
+            - exec airflow webserver
+          resources:
+            {}
+          volumeMounts:
+            - name: config
+              mountPath: /opt/airflow/pod_templates/pod_template_file.yaml
+              subPath: pod_template_file.yaml
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          ports:
+            - name: airflow-ui
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+            periodSeconds: 10
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection          
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config
+---
+# Source: airflow/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-postgresql
+  namespace: "airflow"
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-12.1.9
+    app.kubernetes.io/instance: airflow
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  replicas: 1
+  serviceName: airflow-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: airflow
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: airflow-postgresql
+      labels:
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-12.1.9
+        app.kubernetes.io/instance: airflow
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: primary
+      annotations:
+    spec:
+      serviceAccountName: default
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/instance: airflow
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      hostNetwork: false
+      hostIPC: false
+      initContainers:
+      containers:
+        - name: postgresql
+          image: docker.io/bitnami/postgresql:11
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgresql
+                  key: postgres-password
+            # Replication
+            # Initdb
+            # Standby
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                
+                - |
+                  exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+          resources:
+            limits: {}
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"
+        storageClassName: directpv-min-io
+---
+# Source: airflow/templates/redis/redis-statefulset.yaml
+################################
+## Airflow Redis StatefulSet
+#################################
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-redis
+  labels:
+    tier: airflow
+    component: redis
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  serviceName: airflow-redis
+  selector:
+    matchLabels:
+      tier: airflow
+      component: redis
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: redis
+        release: airflow
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      serviceAccountName: airflow-redis
+      securityContext: 
+        runAsUser: 0
+      containers:
+        - name: redis
+          image: redis:7-bullseye
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command: ["/bin/sh"]
+          resources:
+            {}
+          args: ["-c", "redis-server --requirepass ${REDIS_PASSWORD}"]
+          ports:
+            - name: redis-db
+              containerPort: 6379
+          volumeMounts:
+            - name: redis-db
+              mountPath: /data
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-redis-password
+                  key: password
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-db
+      spec:
+        storageClassName: directpv-min-io
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# Source: airflow/templates/triggerer/triggerer-deployment.yaml
+################################
+## Airflow Triggerer Deployment
+#################################
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-triggerer
+  labels:
+    tier: airflow
+    component: triggerer
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  serviceName: airflow-triggerer
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: airflow
+      component: triggerer
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: triggerer
+        release: airflow
+      annotations:
+        checksum/metadata-secret: cd6de1cad5366c38201917e3ed1ac78bec2655c819758d1fa68bbe0b6539968b
+        checksum/pgbouncer-config-secret: 1dae2adc757473469686d37449d076b0c82404f61413b58ae68b3c5e99527688
+        checksum/airflow-config: cb518829e5fe9057b74ba440d7b440acd1fdb57ee3678787d4eac59009ef70b5
+        checksum/extra-configmaps: e862ea47e13e634cf17d476323784fa27dac20015550c230953b526182f5cac8
+        checksum/extra-secrets: e9582fdd622296c976cbc10a5ba7d6702c28a24fe80795ea5b84ba443a56c827
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: triggerer
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      terminationGracePeriodSeconds: 60
+      restartPolicy: Always
+      serviceAccountName: airflow-triggerer
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      initContainers:
+        - name: wait-for-airflow-migrations
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          args:          
+            - airflow
+            - db
+            - check-migrations
+            - --migration-wait-timeout=60
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+      containers:
+        - name: triggerer
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - bash
+            - -c
+            - exec airflow triggerer
+          resources:
+            {}
+          volumeMounts:
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+          
+          livenessProbe:
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
+            periodSeconds: 60
+            exec:
+              command:              
+                - sh
+                - -c
+                - |
+                  CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+                  airflow jobs check --job-type TriggererJob --local
+          ports:
+            - name: triggerer-logs
+              containerPort: 8794
+        - name: triggerer-log-groomer
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - bash
+            - /clean-logs
+          env:
+            - name: AIRFLOW__LOG_RETENTION_DAYS
+              value: "15"
+          volumeMounts:
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config
+  volumeClaimTemplates:
+    - metadata:
+        name: logs
+      spec:
+        storageClassName: directpv-min-io
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# Source: airflow/templates/workers/worker-deployment.yaml
+################################
+## Airflow Worker Deployment
+#################################
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airflow-worker
+  labels:
+    tier: airflow
+    component: worker
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+spec:
+  serviceName: airflow-worker
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: airflow
+      component: worker
+      release: airflow
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: worker
+        release: airflow
+      annotations:
+        checksum/metadata-secret: cd6de1cad5366c38201917e3ed1ac78bec2655c819758d1fa68bbe0b6539968b
+        checksum/result-backend-secret: 98a68f230007cfa8f5d3792e1aff843a76b0686409e4a46ab2f092f6865a1b71
+        checksum/pgbouncer-config-secret: 1dae2adc757473469686d37449d076b0c82404f61413b58ae68b3c5e99527688
+        checksum/webserver-secret-key: 474d773a800293e55ab1679a5551c1abf3ba2da604eb8b8058c335fa2574f0ce
+        checksum/kerberos-keytab: 80979996aa3c1f48c95dfbe9bb27191e71f12442a08c0ed834413da9d430fd0e
+        checksum/airflow-config: cb518829e5fe9057b74ba440d7b440acd1fdb57ee3678787d4eac59009ef70b5
+        checksum/extra-configmaps: e862ea47e13e634cf17d476323784fa27dac20015550c230953b526182f5cac8
+        checksum/extra-secrets: e9582fdd622296c976cbc10a5ba7d6702c28a24fe80795ea5b84ba443a56c827
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: worker
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      terminationGracePeriodSeconds: 600
+      restartPolicy: Always
+      serviceAccountName: airflow-worker
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      initContainers:
+        - name: wait-for-airflow-migrations
+          resources:
+            {}
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          args:          
+            - airflow
+            - db
+            - check-migrations
+            - --migration-wait-timeout=60
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+      containers:
+        - name: worker
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - bash
+            - -c
+            - |-
+              exec \
+              airflow celery worker
+          resources:
+            {}
+          livenessProbe:
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
+            periodSeconds: 60
+            exec:
+              command:
+                - sh
+                - -c
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
+          ports:
+            - name: worker-logs
+              containerPort: 8793
+          volumeMounts:
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+          envFrom:          
+            []
+          env:
+            # Only signal the main process, not the process group, to make Warm Shutdown work properly
+            - name: DUMB_INIT_SETSID
+              value: "0"          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection          
+        - name: worker-log-groomer
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - bash
+            - /clean-logs
+          env:
+            - name: AIRFLOW__LOG_RETENTION_DAYS
+              value: "15"
+          resources:
+            {}
+          volumeMounts:
+            - name: logs
+              mountPath: "/opt/airflow/logs"
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config
+  volumeClaimTemplates:
+    - metadata:
+        name: logs
+      spec:
+        storageClassName: directpv-min-io
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# Source: airflow/templates/cleanup/cleanup-cronjob.yaml
+################################
+## Airflow Cleanup Pods CronJob
+#################################
+---
+# Source: airflow/templates/cleanup/cleanup-serviceaccount.yaml
+################################
+## Airflow Cleanup ServiceAccount
+#################################
+---
+# Source: airflow/templates/configmaps/extra-configmaps.yaml
+####################################################
+## Extra ConfigMaps provisioned via the chart values
+####################################################
+---
+# Source: airflow/templates/configmaps/webserver-configmap.yaml
+################################
+## Airflow ConfigMap
+#################################
+---
+# Source: airflow/templates/dag-processor/dag-processor-deployment.yaml
+################################
+## Airflow Dag Processor Deployment
+#################################
+---
+# Source: airflow/templates/dag-processor/dag-processor-serviceaccount.yaml
+################################
+## Airflow Dag Processor ServiceAccount
+#################################
+---
+# Source: airflow/templates/dags-persistent-volume-claim.yaml
+######################################
+## Airflow DAGs PersistentVolumeClaim
+######################################
+---
+# Source: airflow/templates/flower/flower-deployment.yaml
+################################
+## Airflow Flower Deployment
+#################################
+---
+# Source: airflow/templates/flower/flower-ingress.yaml
+################################
+## Airflow Flower Ingress
+#################################
+---
+# Source: airflow/templates/flower/flower-networkpolicy.yaml
+################################
+## Airflow Flower NetworkPolicy
+#################################
+---
+# Source: airflow/templates/flower/flower-service.yaml
+################################
+## Airflow Flower Service Component
+#################################
+---
+# Source: airflow/templates/flower/flower-serviceaccount.yaml
+######################################
+## Airflow Flower ServiceAccount
+######################################
+---
+# Source: airflow/templates/limitrange.yaml
+################################
+## Airflow Namespace LimitRange
+#################################
+---
+# Source: airflow/templates/logs-persistent-volume-claim.yaml
+######################################
+## Airflow LOGs PersistentVolumeClaim
+######################################
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+################################
+## Airflow Pgbouncer Deployment
+#################################
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+################################
+## Pgbouncer NetworkPolicy
+#################################
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+################################
+## Pgbouncer PodDisruptionBudget
+#################################
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-service.yaml
+################################
+## Airflow Pgbouncer Service
+#################################
+---
+# Source: airflow/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+######################################
+## Airflow Pgbouncer ServiceAccount
+######################################
+---
+# Source: airflow/templates/rbac/pod-cleanup-role.yaml
+################################
+## Airflow Cleanup Role
+#################################
+---
+# Source: airflow/templates/rbac/pod-cleanup-rolebinding.yaml
+################################
+## Airflow Cleanup Role Binding
+#################################
+---
+# Source: airflow/templates/rbac/security-context-constraint-rolebinding.yaml
+################################
+## Airflow SCC Role Binding
+#################################
+---
+# Source: airflow/templates/redis/redis-networkpolicy.yaml
+################################
+## Airflow Redis NetworkPolicy
+#################################
+---
+# Source: airflow/templates/resourcequota.yaml
+################################
+## Airflow Namespace ResourceQuota
+#################################
+---
+# Source: airflow/templates/scheduler/scheduler-networkpolicy.yaml
+################################
+## Airflow Scheduler NetworkPolicy
+#################################
+---
+# Source: airflow/templates/scheduler/scheduler-poddisruptionbudget.yaml
+################################
+## Airflow Scheduler PodDisruptionBudget
+#################################
+---
+# Source: airflow/templates/scheduler/scheduler-service.yaml
+################################
+## Airflow Scheduler Service
+#################################
+---
+# Source: airflow/templates/secrets/elasticsearch-secret.yaml
+################################
+## Elasticsearch Secret
+#################################
+---
+# Source: airflow/templates/secrets/extra-secrets.yaml
+#################################################
+## Extra Secrets provisioned via the chart values
+#################################################
+---
+# Source: airflow/templates/secrets/flower-secret.yaml
+################################
+## Flower Secret
+#################################
+---
+# Source: airflow/templates/secrets/kerberos-keytab-secret.yaml
+################################
+## Kerberos Secret
+#################################
+---
+# Source: airflow/templates/secrets/pgbouncer-certificates-secret.yaml
+################################
+## Pgbouncer Certificate Secret
+#################################
+---
+# Source: airflow/templates/secrets/pgbouncer-config-secret.yaml
+################################
+## Pgbouncer Config Secret
+#################################
+---
+# Source: airflow/templates/secrets/pgbouncer-stats-secret.yaml
+################################
+## Pgbouncer Stats Secret
+#################################
+---
+# Source: airflow/templates/secrets/registry-secret.yaml
+################################
+## Registry Secret
+#################################
+---
+# Source: airflow/templates/secrets/result-backend-connection-secret.yaml
+################################
+## Airflow Result Backend Secret
+#################################
+---
+# Source: airflow/templates/statsd/statsd-networkpolicy.yaml
+################################
+## Airflow StatsD NetworkPolicy
+#################################
+---
+# Source: airflow/templates/triggerer/triggerer-networkpolicy.yaml
+##################################
+## Airflow triggerer NetworkPolicy
+##################################
+---
+# Source: airflow/templates/webserver/webserver-ingress.yaml
+################################
+## Airflow Webserver Ingress
+#################################
+---
+# Source: airflow/templates/webserver/webserver-networkpolicy.yaml
+################################
+## Airflow Webserver NetworkPolicy
+#################################
+---
+# Source: airflow/templates/webserver/webserver-poddisruptionbudget.yaml
+################################
+## Airflow Webserver PodDisruptionBudget
+#################################
+---
+# Source: airflow/templates/workers/worker-kedaautoscaler.yaml
+################################
+## Airflow Worker KEDA Scaler
+#################################
+---
+# Source: airflow/templates/workers/worker-networkpolicy.yaml
+################################
+## Airflow Worker NetworkPolicy
+#################################
+---
+# Source: airflow/templates/secrets/fernetkey-secret.yaml
+################################
+## Airflow Fernet Key Secret
+#################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-fernet-key
+  labels:
+    tier: airflow
+    release: airflow
+    chart: airflow
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+type: Opaque
+data:
+  fernet-key: "VWt4TFVVcEJOV3RFYjJaSlZITkhOa2xrUVdSM09WWlRWRkZLZWxoSlIxaz0="
+---
+# Source: airflow/templates/secrets/redis-secrets.yaml
+# We will create these secrets (if necessary) _even if_ we aren't
+# currently using CeleryExecutor or CeleryKubernetesExecutor. As we are
+# relying on the "pre-install" hack to prevent changing randomly generated passwords,
+# updating the executor later doesn't give us the opportunity to deploy them
+# when we need them. We will always deploy them defensively to make the executor
+# update path actually work.
+
+################################
+## Airflow Redis Password Secret
+#################################
+# If passwordSecretName is not set, we will either use the set password, or use the generated one
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-redis-password
+  labels:
+    tier: airflow
+    component: redis
+    release: airflow
+    chart: airflow
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+type: Opaque
+data:
+  password: "TTlNZkVLbk9yQQ=="
+---
+# Source: airflow/templates/secrets/redis-secrets.yaml
+##################################
+## Airflow Redis Connection Secret
+##################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-broker-url
+  labels:
+    tier: airflow
+    component: redis
+    release: airflow
+    chart: airflow
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+type: Opaque
+data:
+  connection: "cmVkaXM6Ly86TTlNZkVLbk9yQUBhaXJmbG93LXJlZGlzOjYzNzkvMA=="
+---
+# Source: airflow/templates/jobs/create-user-job.yaml
+################################
+## Airflow Create User Job
+#################################
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: airflow-create-user
+  labels:
+    tier: airflow
+    component: create-user-job
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: create-user-job
+        release: airflow
+    spec:
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      restartPolicy: OnFailure
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      serviceAccountName: airflow-create-user-job
+      containers:
+        - name: create-user
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args: 
+            - bash
+            - -c
+            - |-
+              exec \
+              airflow users create "$@"
+            - --
+            - -r
+            - 'Admin'
+            - -u
+            - 'admin'
+            - -e
+            - 'admin@example.com'
+            - -f
+            - 'admin'
+            - -l
+            - 'user'
+            - -p
+            - 'admin'
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection          
+          resources:
+            {}
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config
+---
+# Source: airflow/templates/jobs/migrate-database-job.yaml
+################################
+## Airflow Run Migrations
+#################################
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: airflow-run-airflow-migrations
+  labels:
+    tier: airflow
+    component: run-airflow-migrations
+    release: airflow
+    chart: "airflow-1.10.0"
+    heritage: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "1"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: run-airflow-migrations
+        release: airflow
+    spec:
+      securityContext: 
+        runAsUser: 50000
+        fsGroup: 0
+      restartPolicy: OnFailure
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+      topologySpreadConstraints:
+        []
+      serviceAccountName: airflow-migrate-database-job
+      containers:
+        - name: run-airflow-migrations
+          image: apache/airflow:2.6.2
+          imagePullPolicy: IfNotPresent
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - bash
+            - -c
+            - |-
+              exec \
+              airflow db upgrade
+          envFrom:          
+            []
+          env:          
+            # Dynamically created environment variables
+            # Dynamically created secret envs
+            # Extra env
+            - name: PYTHONUNBUFFERED
+              value: "1"          
+            # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW_CONN_AIRFLOW_DB
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-airflow-metadata
+                  key: connection
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW__CELERY__BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-broker-url
+                  key: connection
+          resources:
+            {}
+          volumeMounts:
+            - name: config
+              mountPath: "/opt/airflow/airflow.cfg"
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: "/opt/airflow/config/airflow_local_settings.py"
+              subPath: airflow_local_settings.py
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: airflow-airflow-config


### PR DESCRIPTION
**still a work in progress** but we've got a working manual deployment on Andy's Azure VM!

Have a look at `deployment/plat-infra-services/airflow/official/` for instructions to install manually w/ Helm.
Keep in mind on Andy's VM we're running DirectPV so the storage class in the Helm value is set to `directpv-min-io`. If you're using local storage (default option), you've got to set the storage class to `local-storage` and manually provision 4 local storage volumes of 10GB each.

Also keep in mind the deployment takes a while and then the various services take a long time, like loooong, to converge to a stable state---be patient.

Eventually you should get to a point where all pods are running happily

```bash
$ kubectl -n airflow get pod
NAME                                 READY   STATUS    RESTARTS          AGE
airflow-redis-0                      1/1     Running   0                 20h
airflow-statsd-7d985bcb6f-tp6lv      1/1     Running   0                 20h
airflow-postgresql-0                 1/1     Running   0                 20h
airflow-webserver-6d94b95fc5-lrrc2   1/1     Running   108 (14h ago)     20h
airflow-scheduler-6f48fc4d45-rtz2z   2/2     Running   187 (6m50s ago)   20h
airflow-triggerer-0                  2/2     Running   192 (6m48s ago)   20h
airflow-worker-0                     2/2     Running   192 (6m42s ago)   20h
```

and volumes are bound

```bash
$ kubectl -n airflow get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
data-airflow-postgresql-0   Bound    pvc-4c3c4eaa-16df-49a7-82ea-29091413f7c2   8Gi        RWO            directpv-min-io   20h
redis-db-airflow-redis-0    Bound    pvc-97f24ffb-4bca-4e18-9e2a-c76ef85d6156   1Gi        RWO            directpv-min-io   20h
logs-airflow-triggerer-0    Bound    pvc-9b02da4d-1171-4d87-b9cf-9d6e4e36ee5a   1Gi        RWO            directpv-min-io   20h
logs-airflow-worker-0       Bound    pvc-5f6134b0-7221-49ad-a96c-df3757bd7a29   1Gi        RWO            directpv-min-io   20h
```

There's no ingress route at the mo, but you can port-forward to log into the Web UI---use the username/password configured in the Helm chart to log in.

```bash
$ kubectl -n airflow port-forward svc/airflow-webserver 8080:8080
```

Still missing:
- Integration into Argo CD.
- Istio routing to expose the Web UI to clients outside the cluster