### PR TITLE
OPA security first cut

### DIFF
--- a/deployment/mesh-infra/istio/profile.yaml
+++ b/deployment/mesh-infra/istio/profile.yaml
@@ -24,12 +24,25 @@
 #   - https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
 #   - https://www.redhat.com/sysadmin/privileged-flag-container-engines
 #
+# - added extensionProviders stanza to be able to delegate security
+#   decisions to OPA through a custom authorisation policy, see
+#   * https://istio.io/latest/blog/2021/better-external-authz/
+#   * https://istio.io/latest/docs/tasks/security/authorization/authz-custom/
+#   NOTE. With this setup, Envoy calls an OPA service in the cluster.
+#   It's also possible (advisable actually!) to run an OPA process as
+#   an additional sidecar so you never pay the price of a network call
+#   to check security policies.
+#
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   meshConfig:
     accessLogFile: /dev/stdout
     extensionProviders:
+    - name: opa.default
+      envoyExtAuthzGrpc:
+        service: opa.default.svc.cluster.local
+        port: 9191
     - name: otel
       envoyOtelAls:
         service: opentelemetry-collector.istio-system.svc.cluster.local

--- a/deployment/mesh-infra/security/keycloak/base.yaml
+++ b/deployment/mesh-infra/security/keycloak/base.yaml
@@ -36,6 +36,7 @@ spec:
         image: quay.io/keycloak/keycloak:21.1.2
         args:
         - start
+        - --import-realm
         env:
         # Use HTTP (we'll switch to HTTPs later on for pilot deployments)
         # and build URLs of depending on host and port found in the request.
@@ -75,7 +76,13 @@ spec:
         volumeMounts:
         - name: h2-volume
           mountPath: /opt/keycloak/data/h2/
+        - name: teadal-realm-bootstrap
+          mountPath: /opt/keycloak/data/import/teadal-bootstrap.json
+          subPath: teadal-bootstrap.json
       volumes:
       - name: h2-volume
         persistentVolumeClaim:
           claimName: keycloak-pvc
+      - name: teadal-realm-bootstrap
+        configMap:
+          name: teadal-realm-bootstrap

--- a/deployment/mesh-infra/security/keycloak/kustomization.yaml
+++ b/deployment/mesh-infra/security/keycloak/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - base.yaml
+
+configMapGenerator:
+- name: teadal-realm-bootstrap
+  files:
+  - teadal-bootstrap.json

--- a/deployment/mesh-infra/security/keycloak/teadal-bootstrap.json
+++ b/deployment/mesh-infra/security/keycloak/teadal-bootstrap.json
@@ -1,0 +1,1827 @@
+{
+  "id" : "31050d73-1b5a-4756-84bd-d8a12b4b7eb7",
+  "realm" : "teadal",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "0a60ea80-2f1e-46ed-bb47-3ba7df45e1d1",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "31050d73-1b5a-4756-84bd-d8a12b4b7eb7",
+      "attributes" : { }
+    }, {
+      "id" : "ca0a1f1b-e1ed-4ca3-a191-f143e0f8a67c",
+      "name" : "default-roles-teadal",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "31050d73-1b5a-4756-84bd-d8a12b4b7eb7",
+      "attributes" : { }
+    }, {
+      "id" : "f68f18b9-f838-4666-a6f6-364af3aa47df",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "31050d73-1b5a-4756-84bd-d8a12b4b7eb7",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "26dad4a6-1b4d-44b3-a913-04eca6010540",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "b3ccad33-99c1-4ac0-bf37-f58814cb3bb2",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "26fac37a-cc37-4339-a889-f8d01e6ae7d8",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "8daae874-f71b-43e1-928a-e04de556761b",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "773b2ec8-7856-43d7-96a4-0ea2fb0d8d36",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "3f16d0c8-1bf8-44f5-b03c-dcb5b9258d1d",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "b96309dd-3eb3-45d8-9dff-b52b183c12ea",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "61f43fd4-e0e3-4a94-a883-b9660f8551d5",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "2ac86ccd-1b6a-4122-8db6-e72aa0736f21",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "31c22b44-380e-4e15-a6a1-b84c02334571",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "2eb6b24d-f8dc-49fd-897e-75a3b0f7b4ea",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "5e87d4f8-93e9-41c0-9dc2-abd6fdf9514d",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "8df4e9dd-9a1e-4ea7-af43-a1988cb0cb06",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-users", "impersonation", "manage-events", "view-users", "query-clients", "manage-identity-providers", "view-realm", "manage-realm", "view-authorization", "view-clients", "query-realms", "manage-authorization", "query-groups", "create-client", "view-identity-providers", "view-events", "query-users", "manage-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "8dcbffe9-244a-4d77-911f-99d7a9b85664",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "e0792ad5-b3e1-4b36-8df0-191a88352663",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "ae05a469-d2be-40c4-9868-17f193efee39",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "e53e4d30-47d9-4ac8-a14e-2dd3cb8c52ba",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "e087409c-2c00-4a15-bd0d-cbe0bae34762",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      }, {
+        "id" : "8893231e-60b2-46e7-8b61-9dae24073f1d",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "4465ed36-6ff7-4e16-9218-c9831cdc8ea4",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3b667c08-f848-4337-86ae-c9f24ad5d4a2",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "ad62594c-6120-4696-8465-0da993666eb2",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "a842d484-5cf4-4548-9c3f-2286f1d0c117",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "fd26b83d-eb07-47ef-a76f-ca7502f5062e",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "90a247f7-4fb4-4ed7-9859-b0a7302359a0",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "431f7e4a-870c-49e1-b89f-2f340c02fa15",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "adbef5f4-0fb3-4595-842c-3ca7b72b410d",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "b6efdd65-74f2-4813-b325-7bc09c3a01d3",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      }, {
+        "id" : "8cded4d2-1613-4545-985d-0bf95612250b",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "ca0a1f1b-e1ed-4ca3-a191-f143e0f8a67c",
+    "name" : "default-roles-teadal",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "31050d73-1b5a-4756-84bd-d8a12b4b7eb7"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "1e811923-9be5-4729-a809-d306df1efd28",
+    "createdTimestamp" : 1696871108976,
+    "username" : "jeejee",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "",
+    "lastName" : "",
+    "email" : "jeejee@teadal.eu",
+    "credentials" : [ {
+      "id" : "3b7dc9e7-2204-418a-a911-1d523afc9eb9",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1696871128550,
+      "secretData" : "{\"value\":\"TiCNJWONFM6jAVggUX3B/LVu3b5VYiJe9shY2ExAGvE=\",\"salt\":\"hmJAsn4hKhJjOxzdc48F+w==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-teadal" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "83cd7e76-334a-4010-bc82-d3c93713bb1c",
+    "createdTimestamp" : 1696871143126,
+    "username" : "sebs",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "",
+    "lastName" : "",
+    "email" : "sebs@teadal.eu",
+    "credentials" : [ {
+      "id" : "07dc2ebb-9c13-4024-940e-884f9481d59a",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1696871159427,
+      "secretData" : "{\"value\":\"jIc6k87ARK9a5iTmrlKijkf/SNbrv/XGf4cq968NEXU=\",\"salt\":\"hk0E54Hxlgx1Sn3LAsSL8w==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-teadal" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "97b20be2-b8b7-4b53-8f25-1184081890a0",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/teadal/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/teadal/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "350bf00b-dab4-41b9-8d2f-74ebc410ed1f",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/teadal/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/teadal/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "9180c0a9-d441-4b93-93f9-c9cd6fca6bc5",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "d3584e13-8d7f-4dca-abed-4113a31be6b8",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "3b667c08-f848-4337-86ae-c9f24ad5d4a2",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "f6cc9490-21fc-443b-aa9d-8f59e1a2e921",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "c031238b-91b6-4754-a666-8a4b97e70b93",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/teadal/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/teadal/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "65543ac8-e8cc-4dab-be69-f390085fd288",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "49964cf5-8ec7-4bf4-ad6a-060d3e24c6ab",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "9e6b281d-7588-4463-b385-17d0c4ce54d2",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "624a16c4-f290-4753-a363-a7c8ba1518bb",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2a968f04-5139-4dc5-a190-15c68e192b02",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "53824739-0a1a-4dda-8ec8-8dd1e19d348a",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5c9302f0-dedb-4795-877b-f20d6cb2141e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4fd6c395-b965-4c84-a514-f3cf068c3c27",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "829ba7a2-391a-42ba-8ce4-bf3fc7f01103",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a21049d0-9962-43be-9281-6ecebc5e74b0",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "272a536b-1f2f-4f15-8861-aea88d0070a9",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3423bd29-5d95-4db0-8883-c231898c8748",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7b60cfb9-b1bb-41b9-bff3-84223284d526",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "161154cb-1bc0-4559-8e36-2433ca295f11",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e8e503cb-ebf9-47d6-bea0-f5323b72bd8a",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b32e1883-25b6-4d14-bee4-ac2ba8a02eba",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "363dcf68-922d-4f0e-917f-291841ec86e9",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "ff7094ad-1ede-4882-a6c9-0c2b293c97af",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "9554e0e6-45c7-49e1-9af1-d3f0b90f5442",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "436518a4-6516-424d-a25d-00a2f0960e8a",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "2a58c77b-0ed1-4aff-985a-16c157294adf",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "99436c73-5c52-435b-ab74-175bee1089fc",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "409fe116-954c-4bb9-9b79-827e036fe0c1",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "29772267-558a-4fd0-a6e8-c0b56596d058",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "bbc72f31-090c-43e8-bb4d-5a6b3cfd0882",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "5445f23b-4b99-4945-b35d-33951c5901ea",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "10766a3f-b958-4e0e-8201-038b2729efb3",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "8b2a3394-8b10-4f78-953f-89225e53be15",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "4231b6ce-31cb-4e7a-94d4-70f9010e89cf",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "60d50ae4-0e0b-4f3c-ae60-d26bb8c81de8",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fb3b4451-5e4b-4839-be75-be41c1ed4836",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "87047b46-739e-4dcc-9ed7-3668170b8842",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "ee925d15-08da-4971-8fc2-e66083a0ff5e",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "5b176460-8639-4b34-ad54-a1e33dc6cc8a",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "4ab31220-1698-4efb-ad81-0cfa0782b17e",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "8ea395f3-759c-48fd-8b20-0e62f0b9adf0",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "4c5aabda-dd98-4195-ad99-7e49c777b696",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5f1c08d5-5177-44c5-b1aa-260bb15724ce",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "73e3c02e-5bae-418d-98fb-f70d3ad8185c",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3415fd8b-6739-4c91-95a1-cbb6389107b5",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "13bea6cb-b946-4af0-b060-7d72640cb943",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
+    }, {
+      "id" : "4d1d9932-9f24-4aba-b0dd-595131034e4d",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
+    }, {
+      "id" : "228bb3d4-93f9-40f8-b6ff-48437cac8a3d",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "3d46c23b-297a-4725-9845-715a7017e457",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "64c11227-35a3-4003-be54-5ed804acfb8c",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "ac053e9a-d48e-4858-a10f-efa63eb74e16",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "721e1a7b-c62a-4697-9cb4-15c5f6d7a878",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "7f6f0b80-d8df-44f1-8060-f08ff788f97c" ],
+        "secret" : [ "YgiarDHZJsadj0Ru8Ysfew" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "896fc6cf-8ac7-449a-9d92-7c1ea41ef805",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "8fa60852-8441-4432-8e89-ddb90984a985" ],
+        "secret" : [ "OM82fODL3SgXy9BnoIxk3-hYpS51iqqpAu72OK8Tj7oWQG4bOcmMA_a-oMnzoPPiW4dHQSltA1zoytTMw6WOqQ" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "6faf232d-4434-4646-93b5-e398138ba4ef",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAw7lsijasgStBJ4PEnRRtq2eAujuwZ+Ascbve86PsS18SAJiczV/mo5QchVbmL41q8IXNGmmpIvSkAYRpCRvtQ8E7juUVIqzU0xuUvH6E/RX06Z7eNccjPCD/V4XAFb8QSmULEz1fo3+O0t+RVAWyon1Fb571iCHTwxIS24qrUyfVFM5uCe+483qOPSjxQsYA6davbkU+DYKWxZIJhIsrE29wMA4aZRqG6KZv/DhQIGT+XSjiwZSkKB8e/xtvXzM18rabj/50xaVtMF+Kb7j79BkLItOT5cio5UoWsYVPbUu1TLLqMpthGWrPDDgK9pV+L3ZCyF7mtBu0OC3UZgLWAQIDAQABAoIBAB8MoWK5EwYCyKPuIW4R5DwBgB212QxW4ctr1GNY/o65FvAFReAcIJ3pTIT9U32jtPKnJ0coupjoWm7rLzEvaaUKrdoYuWZLfg+8xmGzaIGFztk+R14cqJhMsR/qAJ5H4IZiH9mo2NflJSaK1PvmqNS3hCEVrznYs/Fe7U2VYrceyO77LNl9Y86C85+r9qw6HFktCnP7o3Pmbkzcv/iCoqlIv1IKLhMEKkxeljMEXgI+ML0XZKJDnMGSRDFZjCjEfrCXQao+gc/j/zQR6iYCrXMPzVumT8oFO5uHwz72bzROHtwCIkH1MQn1/EBFGks4bscLt32EskTwuTPTR4hpEGkCgYEA/sZc3dVBF1iduDVEKdmMsz9f2UU6U5bvYcocC3HdklyxoSRRXnhrbP7CsUjt992VuvVwkgJ6gedr3aEJq/dctCTQTYSQ2FNOafYOcnnBrTKTQQyDdXvYyOvMRXy8BNOABHJ8VGPt/spwnkNsNp1num+8a9MoXxQSeJpN+NqAhzsCgYEAxKpeKhGH16F+BEY//dLjPTPHVLtJRqGaW/QlhP5wc+VTquVaiJzudzCaMHxupaUmbAS2+eJOq9GGi5dqSbF2Oht/QiOnOmt3bDhFJ3V6VUu14GSXHQKkTpir/coPeuS3X2EGnMxPgw/Z0F6nKOWQE8Vgit/V3TEXiy+EeMfJ2/MCgYEAselJTmut8aSjNtCTkfnmRAG8aBfsvBSJg6tEXEWeaaerLxESdTr4IXvh7zUzYERvW8grXPq4G+DENVdQTrMFHJMclxU8pKO//USjIBOgSNcpd2JKpo7eeqgW1GtfTKt5GSHtam0B9EvfytTgS18t4UZHuLAS4Bo/L9LpIh9LY6MCgYEAkrOfkHQJSBGgRiH9JCNG/WV9gLhAXd64nXVO85k1W06rDeUOlq+xttlbe2WmyAuc0KDnuRlWpBak7cYiNByb25adZEHiQdLef6yt8VRR0AStBFkk3DAXTsXWLnem+n5YR17CJv7FJTgSu7uPqBMuWYE3lgCIsPoo3NuyTsKB0n8CgYBiwDqZGSwDETrc0o1TwgyowNR6d4nn9iZPhTzBou0leJUDNxOh6uFG3r7aHMTMeCPP7XR+dbok1hasobvyiPAt+5eBC5JFQPinbQjrKaqQkXSu9CDFp0nbSlo2rGiBcgKDja2aBogVWbX6DpfN1uHDFTqM+zmk41CNCynjxdDsqQ==" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICmzCCAYMCBgGLFWWcKDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ0ZWFkYWwwHhcNMjMxMDA5MTcwMjQyWhcNMzMxMDA5MTcwNDIyWjARMQ8wDQYDVQQDDAZ0ZWFkYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDuWyKNqyBK0Eng8SdFG2rZ4C6O7Bn4Cxxu97zo+xLXxIAmJzNX+ajlByFVuYvjWrwhc0aaaki9KQBhGkJG+1DwTuO5RUirNTTG5S8foT9FfTpnt41xyM8IP9XhcAVvxBKZQsTPV+jf47S35FUBbKifUVvnvWIIdPDEhLbiqtTJ9UUzm4J77jzeo49KPFCxgDp1q9uRT4NgpbFkgmEiysTb3AwDhplGobopm/8OFAgZP5dKOLBlKQoHx7/G29fMzXytpuP/nTFpW0wX4pvuPv0GQsi05PlyKjlShaxhU9tS7VMsuoym2EZas8MOAr2lX4vdkLIXua0G7Q4LdRmAtYBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAAkLhtp777Q37YV3oqEJe5IfRhc1Zsz9d7xeNGR2uVtawi2XqjjLjpcXxoM92J6yh3WSbzUFXAd+/bwhGy+yNRRAopbpO1Hfsz0i2khc0+VuX2350/4IhXF8jXRkKf+EBwwpbh7vtxuXrGE49zh8nVQA5XIv4tBlD7lrjnPyGKY7Ggonjz434UTTOwxKtrPtD1ApdIl0MYYx5TP4yffUNkWr27faBBcDPGLRX/rLpDl+5PUgk+l1Iywqt+nyycCcSvlWmkU6kd3WpXAsIssVZPmvGjsNJZ+bP16Ce540NQTkp3YU9VEC7+gPZ1Vz8KehdQrV8sYuKtthi589eq/3xSg=" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "b9fe47e2-d056-4236-b20e-6b6555175cd2",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAn5S5Fn1WABrwlUaFnrwiRZomkQ3CvflUw7bwrYZi0kfleDqDMRj0SLHapUqYCStddQZGSQzbMd1sTSBQcPOY/863pwHN40kDgEzY1pbKMmovoYgbhzJS/qhTVARQjMank5ecjcvk3hBrcGRI9Fh+uaea9XkC9yziH6mRDRVn97x6XtRGd850h5l+zzV/vwNahvjrnk2t0NNMuP4ei39lT5eotPNAhkMmeDzwPvRD3r25757l1JqmlXxPRoEJhJByF7vqQF4yWTf+xNfIBc8oV0Or2yq0podfxZjNZWRvCeSCwpGncuca6RXfbkoGLPlTHb2hl0Ph81ETZxgHoWo0uwIDAQABAoIBAAIH6ViqbOeZjJ1/823xWDmlw01VLRx3RiPV8sy+Guyiu35i783vNk/Ih6uoTFDtjttRIoO+7fk2p5QHCN1Ed++600L2y/hFCDjf80XZMqbJtmQ/mwb4gLWQMdif0+CbOCv42tDst2xwvA4xnsKDGnlTnecwMAP5Zmxtu78gDAFnt62C0IbXVeDIgWGH/vpi22v5qKQV03iCgVEXdrKpqv2PvuHZuhvLglw03zLomfmAlsVB+1VWkbObzTTTj1I/d+21cs+rUZe7060jjPkwiCHCrZt7Z+0FdWmIS4am1zCOUl4Vlu+w8BMNSKFJNqEeEm2U+w1WWv7wRCvy2umMMdkCgYEA1CHzhqH38oCYpGLlkwj2XN6anV41Ee9xBCc2x2U4pcn5eBO2Gxqya/GW0Kqtx9a1hIsjG6Kwla9t0e3U0FQzEZHy9Xx5TLHB5xlM4ZIN1lQylCaxWZmIcItJ//1rw+Rl5979KvaX7xyaRrudePxdleTY1o2fHvBNRCnLyR13f1MCgYEAwJS/qDjH+wrTGo+hXJLWiPAUuadN5VsxZdW6yWAbPF+n+lu4CN5bSqIq6xwWMf6Me0i7HBCxbKskL25dxgLiOazWYwmqKH+eYSybWtwg0IhVnRHc94qM3FZHCvrUPkSPQQ3qfVq0XFlBbYSqOW6HuSr0zDxrHAAnq4A8PbWwj/kCgYEAtbCuqC2p9KZ4FrQt9ZXDjR+MRiUeR1JR9kCwBnCH6FfpuBMJ8oUXNKUji23kkjkwF2okk9LwdARhh2Cw2g6D/xSGiAQo0KufbJSa6Mjz2RMcjw/k7t01o09p/jvMRWgmcEbpiBbVYxOYf+TJp4pfjbcIkhuSoiknxK4XwRXf98kCgYBlxPW3ZzI/NwwyKB7ktfBLc1vwdDpU7ykeoKDR1EjwUbiKNDf/78mcmjBGCJSuHM+OQvQmM6gfPh2kNxW1E0cLpYux0KSsPCytO45pqJRqvvFHTO5RnlUsBygJ5F2O/loZzcnSLsHLX5uUzZvLN97fepTc7TzJEkfkeKLdFYvVuQKBgEWDXM05tlWX79Qty5prqDHMfgCIBYw+cq7jR4QETdr4M+RKf/FeqKzSOimvLN5NiT9xl/zbL9x7XCdthqf2dUgBLBL2wtE6Rg5Ygj7cxdshf+6hWTlZRa7IePYr3rjbr9f9ZUQeLq/TZ6ccCIHBH0QgL3ekR/Nw29xAkIqz8VKn" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICmzCCAYMCBgGLFWWbPjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZ0ZWFkYWwwHhcNMjMxMDA5MTcwMjQyWhcNMzMxMDA5MTcwNDIyWjARMQ8wDQYDVQQDDAZ0ZWFkYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCflLkWfVYAGvCVRoWevCJFmiaRDcK9+VTDtvCthmLSR+V4OoMxGPRIsdqlSpgJK111BkZJDNsx3WxNIFBw85j/zrenAc3jSQOATNjWlsoyai+hiBuHMlL+qFNUBFCMxqeTl5yNy+TeEGtwZEj0WH65p5r1eQL3LOIfqZENFWf3vHpe1EZ3znSHmX7PNX+/A1qG+OueTa3Q00y4/h6Lf2VPl6i080CGQyZ4PPA+9EPevbnvnuXUmqaVfE9GgQmEkHIXu+pAXjJZN/7E18gFzyhXQ6vbKrSmh1/FmM1lZG8J5ILCkady5xrpFd9uSgYs+VMdvaGXQ+HzURNnGAehajS7AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHyuzyZDPjcQ5EmmyrtmmmsIyOPKHxB9CRGo6Ek5JOLIVRSazMOGp6DW5qngHrGwxbA/jMtRF7Ri3/Mivds6oKw7+iM6Qcdql+B7LdDfnqZk6CqMq+bQAdvdSNLKjf5q1TCE1AnaUUCEVbxSDARF0NOMfff6jaWPMdabQX/pXsjGI7oGHdsgb41No1MdPM8ec6R4fCWazebvRtQixnTOZZD7P1qJGvC1sEb1a0SMxjt5egpUhAdxheqR+ZjqDpUmuO4qOOy5KsSpHRNbB6/4yg7mbAA1bXC8lRRxhKq7NC3EmbisNXDQF7v5cQZkcTwWGtawez/SMM5EEikdrcT4Zi8=" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "482c2778-5787-4403-b7c4-f1bd610cbd49",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d7b1aa50-1ba5-49f3-aa8a-9bd60d303810",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "1d351c50-391c-4802-9690-d097d8ab91fe",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b4c33533-ab3e-45fd-b13f-47ccdca3793e",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d5b156cc-7003-47f7-8d46-182703e8a4d0",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0ef5b0ec-504f-4326-a235-b753e8f071a6",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "608302a6-67c1-4eb2-8577-87986a236ceb",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "604400dc-d61e-48e7-a09b-d789745b9a8e",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "feb4a753-7e4c-48e5-b6f9-2d7ae52cf068",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "bc9a5224-e3ac-436b-8719-1f88abf9bd77",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "dd8d5ce4-c002-4adb-be68-899230c2991a",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a5cd4020-2ac5-4b20-8fb2-e688bf7af2a4",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e054934c-612d-4fbb-a64a-45cef25d3197",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "20ea0263-a9af-495b-8fb1-1cd65bdf588c",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c7d36be2-d13f-4b7e-b999-e3a774c36e38",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "677a8f5c-8edf-4acd-9708-a5fcdbf74acb",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "bd6cebe7-96a0-440a-a432-d83202ca9b9d",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8ebedbf7-f60a-4180-8d5c-b23a8bb1136b",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "7f54514e-8156-4633-8e6e-bbf0aacc56bb",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "2276338a-8aa2-4b21-9375-764581608931",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "4d62e869-df02-4612-96e0-337100233e08",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "5f49f73a-24b0-4016-b737-6e73b67eacaa",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "21.1.2",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/deployment/mesh-infra/security/kustomization.yaml
+++ b/deployment/mesh-infra/security/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - keycloak/
+- opa/
 - reloader/
 
 # NOTE

--- a/deployment/mesh-infra/security/opa/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/opa/ingress-policy.yaml
@@ -1,0 +1,34 @@
+#
+# Secure access to the cluster by delegating authz decisions to our
+# OPA instance.
+#
+# Notice this rule applies to all traffic through port 80 of the Istio
+# ingress gateway, except for some paths. We could be more specific if
+# need be---e.g. have separate rules for different services, ports, etc.
+# instead of this catch-all rule at the ingress gateway level.
+#
+# See also:
+# - https://istio.io/latest/docs/tasks/security/authorization/authz-custom/
+#
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: opa-ingress
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  action: CUSTOM
+  provider:
+    name: "opa.default"
+  rules:
+  - to:
+    - operation:
+        # Ask OPA for permission to go ahead w/ any incoming request except
+        # for requests to Keycloak and Argo CD.
+        notPaths:
+        - "/argocd"
+        - "/argocd/*"
+        - "/keycloak"
+        - "/keycloak/*"

--- a/deployment/mesh-infra/security/opa/kustomization.yaml
+++ b/deployment/mesh-infra/security/opa/kustomization.yaml
@@ -9,5 +9,11 @@ secretGenerator:
 - name: opa-policy
   files:
   - rego/main.rego
+  - authnz.envopa.rego=rego/authnz/envopa.rego
+  - authnz.http.rego=rego/authnz/http.rego
+  - authnz.oidc.rego=rego/authnz/oidc.rego
+  - authnz.rbac.rego=rego/authnz/rbac.rego
+  - config.oidc.rego=rego/config/oidc.rego
   - httpbin.service.rego=rego/httpbin/service.rego
+  - httpbin.rbacdb.rego=rego/httpbin/rbacdb.rego
   - minio.service.rego=rego/minio/service.rego

--- a/deployment/mesh-infra/security/opa/kustomization.yaml
+++ b/deployment/mesh-infra/security/opa/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ingress-policy.yaml
+- opa-envoy-plugin.yaml
+
+secretGenerator:
+- name: opa-policy
+  files:
+  - rego/main.rego
+  - httpbin.service.rego=rego/httpbin/service.rego
+  - minio.service.rego=rego/minio/service.rego

--- a/deployment/mesh-infra/security/opa/opa-envoy-plugin.yaml
+++ b/deployment/mesh-infra/security/opa/opa-envoy-plugin.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa
+  labels:
+    app: opa
+spec:
+  ports:
+  - name: grpc
+    port: 9191
+    targetPort: 9191
+  selector:
+    app: opa
+
+---
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: opa
+  labels:
+    app: opa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opa
+  template:
+    metadata:
+      labels:
+        app: opa
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.53.1-envoy
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+          - readOnly: true
+            mountPath: /policy
+            name: opa-policy
+          args:
+          - "run"
+          - "--server"
+          - "--addr=localhost:8181"
+          - "--diagnostic-addr=0.0.0.0:8282"
+          - "--set=plugins.envoy_ext_authz_grpc.addr=:9191"
+          - "--set=plugins.envoy_ext_authz_grpc.query=data.teadal.allow"
+          - "--set=decision_logs.console=true"
+          - "--ignore=.*"
+          - "--log-format=json-pretty"
+          - "--log-level=debug"
+          - "/policy/"
+          ports:
+          - containerPort: 9191
+          livenessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTP
+              port: 8282
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTP
+              port: 8282
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: opa-policy
+          secret:
+            secretName: opa-policy

--- a/deployment/mesh-infra/security/opa/rego/authnz/README.md
+++ b/deployment/mesh-infra/security/opa/rego/authnz/README.md
@@ -1,0 +1,29 @@
+authnz
+------
+> Eensy-weensy lib for role-based access control of RESTful services.
+
+This library lets you easily define role-based access control (RBAC)
+rules to protect your RESTful services and then enforce those rules
+on each HTTP request.
+
+Features at a glance:
+- Declare your RBAC roles, users and rules in plain Rego using an
+  intuitive DB format.
+- Easily query the RBAC DB with `authnz` built-in functions or roll
+  out your own Rego queries.
+- Choose any OIDC-compliant IdM (e.g. Keycloak) to manage your users
+  and identify them through JSON Web tokens (JWT).
+- Let `authnz` handle JWT validation for you---from OIDC discovery
+  to JWKs download to signature verification, `authnz` does it all
+  for your under the bonnet. You can also use a static JWKs though
+  if you like.
+- Seamlessly hook your RBAC into the Envoy OPA Plugin to enforce
+  your rules.
+
+
+### Usage
+TODO
+
+
+### Hacking
+TODO

--- a/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
@@ -1,0 +1,187 @@
+#
+# Example config to tweak `authnz` behaviour.
+#
+
+package authnz.config
+
+#
+# The name of the JWT field containing the user handle. You set this value
+# to tell `authnz` which token payload field contains the user handle. The
+# user handle should uniquely identify the user with the token issuer.
+#
+# Typically with Keycloak, you'd use one of `sub`, `preferred_username`
+# or `email`. For instance, here's a payload snippet from a token Keycloak
+# issued to a user named `sebs` having an email of `sebs@teadal.eu`:
+#
+#    {
+#        "iss": "http://localhost/keycloak/realms/master",
+#        "sub": "152f391c-8d9c-4c7c-a67b-924956d8892c",
+#        "preferred_username": "sebs",
+#        "email": "sebs@teadal.eu",
+#        ...
+#    }
+#
+# Notice the `sub` and (hopefully) `email` fields are globally unique,
+# whereas `preferred_username` is only unique within a Keycloak instance.
+# So when doing identity federation, ideally you'd use either `sub` or
+# `email`.
+#
+# Keep in mind the user handle is also the string you must use in your
+# RBAC DB to refer to users. `authnz` looks up RBAC users by that handle,
+# so it's important you use the same value known to Keycloak in your RBAC
+# DB. For instance, if you set `jwt_user_field_name` to `email`, then
+# you'd refer to `sebs` in your RBAC DB by his email:
+#
+#     user_to_roles := {
+#         "sebs@teadal.eu": [ product_consumer ],
+#         ...
+#     }
+#
+jwt_user_field_name := "email"
+
+#
+# Preferred URLs to retrieve issuer JWKs. A map (object) where each key
+# is an issuer URL and the key's corresponding value is the absolute URL
+# where the issuer makes its JWKs available for download. The key's URL
+# must contain only scheme and authority, not the path---e.g. http://my.host,
+# http://my.host:8080.
+#
+# `authnz` can dynamically verify token signatures by automatically
+# discovering, downloading and caching token issuer's JWKs. In fact,
+# OIDC caters for that: if you append `/.well-known/openid-configuration`
+# to the token issuer's URL (`iss` field), you get the URL where to
+# download the issuer's OIDC config. In turn, that config contains a
+# `jwks_uri` field with the URL where to download the keys the issuer
+# makes available to verify token signatures.
+#
+# There are cases where you'd like to use a different URL to download
+# the issuer's keys rather than the one `jwks_uri` specifies. Typically
+# your IdM (e.g. Keycloak) and OPA both run inside your K8s cluster and
+# external clients access your IdM using your cluster externally visible
+# domain name through which you route external traffic to internal pods.
+# Say your Keycloak is available to external clients at
+# - https://idm.my.cloud/
+# and to pods inside the cluster at
+# - https://keycloak:8080/
+# Now when Keycloak issues an external client with a JWT, the `iss`
+# field will contain the externally visible domain name, e.g.
+#
+#     {
+#         "iss": "https://idm.my.cloud/realms/master",
+#         ...
+#     }
+#
+# On seeing this token, `authnz`, as explained earlier, first downloads
+# the OIDC config from
+# - https://idm.my.cloud/realms/master/.well-known/openid-configuration
+# and then follows the `jwks_uri` in it, which in our example would be
+# - https://idm.my.cloud/realms/master/protocol/openid-connect/certs
+# Notice how, given these URLs, OPA, which runs inside the cluster, has
+# to make HTTP calls that get routed outside the cluster and then back
+# in to reach the internal Keycloak pod at https://keycloak:8080/.
+#
+# Wouldn't it be more efficient to use the Keycloak internal URL to
+# download the JWKs? The `jwks_preferred_urls` map lets you do that.
+# If `jwks_preferred_urls` has a key equal to the token issuer's base
+# URL (scheme and authority, e.g. http://my.host), `authnz` uses the
+# corresponding URL value to download the JWKs. For instance, if
+#
+# jwks_preferred_urls := {
+#     "https://idm.my.cloud":
+#         "https://keycloak:8080/realms/master/protocol/openid-connect/certs",
+#     ...
+# }
+#
+# and a JWT comes in with an issuer of
+# - https://idm.my.cloud/realms/master
+# then `authnz` will download the JWKs from
+# - https://keycloak:8080/realms/master/protocol/openid-connect/certs
+# instead of
+# - https://idm.my.cloud/realms/master/protocol/openid-connect/certs
+#
+# If there's no key in `jwks_preferred_urls` that matches the issuer's
+# base URL, then `authnz` uses the issuer's OIDC well-known config to
+# find out where to download the JWKs from.
+#
+jwks_preferred_urls := {
+# Here's another example where `jwks_preferred_urls` comes in handy.
+# Say you're testing your K8s cluster in a VM running on your box and
+# the VM is connected to your loopback interface (localhost). You use
+# path-based routing to access K8s services and your IdM is at
+# - http://localhost/idm
+# When you get a token from the above URL, the issuer field is
+# - http://localhost/idm/issuer
+# This will never work with our `authnz` lib, because `authnz` tries
+# downloading the OIDC config from
+# - http://localhost/idm/issuer/.well-known/openid-configuration
+# but `localhost` resolves to OPA's pod!
+# To fix this, we explicitly set a preferred JWKs URL pointing to
+# the internal pod running our IdM
+# - http://idm.prod.svc.cluster.local/jwks
+#
+    "http://localhost": "http://idm.prod.svc.cluster.local/jwks",
+    "https://localhost": "http://idm.prod.svc.cluster.local/jwks"
+}
+
+#
+# Static JWKs config. A Rego object representation of a JWKs.
+#
+# As mentioned earlier, by default `authnz` doesn't require any key
+# sharing and/or config to verify token signatures as, for each token
+# that comes in, it automatically discovers, downloads and caches token
+# issuer's JWKs. But you can override this behaviour by providing a
+# `jwks` config object with your own JWKs data.
+#
+# If the `jwks` is defined, `authnz` will use the given JWKs for
+# **all** incoming tokens and never make HTTP calls to discover
+# and fetch OIDC config.
+#
+jwks := {
+    "keys": [
+        {
+            "p": "8ybS9TowEW0Y0xHpGBm7LGLoc5u8IF-EkuTFdFZ4DchkeFL1M0ditEJEUV7OlKWErxwRGWo6bA7rLmNA8URZZl_SlSYgWcDeKwHwGqrMXgTydzflYxRmS8azenSoXkiDxFE2Y5psq-6mXmlNYlimV0b7jIylgUUtRX1DAzI42fc",
+            "kty": "RSA",
+            "q": "tXKzhk6uYZoL8bkpVrp0xouyhWhgdAcXN5vDlx98aojbD4DkFj4Zd7_Utl9s5HWYEMJPvMTiYUDaJdkeSDBrmA4OH_4QS5R1DqVvBBMq3JJXvVzaZox7ysWXPeEnNXcYFK_qhtnFHN-ztTWk-WmcWaU-nfgg5WEwfrlRyLTD1nM",
+            "d": "M01swzjoerZOvgl0pzAMF-oFloXvxdKPl7BRybqyv1NpVPEU9MfgM3eegNXHl4YBsq3zvgeXAqWDGuxCw23Vn0NtNqTxud4NIb3JI1S42Ez8m8SXvrsphXLWNQ-AT0QO10aa6S9MVKDHtXzw5LcFj39Hz6Z50Pw9L6rYReRkJF3sKJDv9mUjT9unobgHlnc99HQ-XB9r2md0WwdZI6COXAMT32Fgb9ZhBrq8VyhRiZLje7zmiPqYaB5XQKq6mJLhq26yvZ0leQw7DGVZ0Ot9FpdQky3_T80zhXxYi1-6-dttVhdlRGFsAjjXLPtbWhVTObDDKlcfzC7PWZkJhhO7_Q",
+            "e": "AQAB",
+            "use": "sig",
+            "kid": "k1",
+            "qi": "L2QvQX9uB1anD09Ai0ANKhAeWkRbFKRBBLSaCmV9ZteQeHuG_HUEdZp5NSzg0B4yySLsgT37-1Yc0PZNHWDWltIi7PlwpSiTuDpXRHHQlZOwfLKnu40JtJWgIw8e_yFga5SfcoUuv727GAiONQYXhIKDb1PkpXzEvwQQuoDidVc",
+            "dp": "h7acunj-yUsuNujhRC1gdjbCbXx39U267k44E2YL3g2CXlJXP4bRhbES9qPHA9qagy5UMO5Eq3lsNNj7L26pw2UqYUsFdXMbzb9oJ0o7hSKXvoj5RGLncdX26RthujYZLaLyi4durkwmmb2GjqTSOxaIYntCCTP2P7nZhFgsuSM",
+            "alg": "RS256",
+            "dq": "pVCx3AZHvskZZMysq0YKKvMQXZfxeQUU1CdoloGrW20BGSj3poRBs-blKJvcnHG_cFV5TKWdE7qAhsdAXckv3kO__sn9kr7Zv9ReRzonbPswUWkN2yzXhLFt0IUYsg-lswNsDBzRCDOQieMsQclFGDAD0u1FG3fnNS4nI1P-sZ0",
+            "n": "rFdk9QnnPyQXhPgmHXtF7WupI3aCj-2YVprjEPkra-fPtxKRBjEC0AlDi7BhYilZzcpB2MGKAjzUvfKp7YFwAw7fp6M0fHKRyMtGDCzuu0bv6LX4uLFqLeft8UyjYX1Al3LVmX4VmRxVy88BxFh5H85WMtAOy3JPLYVpf6XZ7fOFEkNyzLY2hYklfsnbvG8ZJyNgAOTSx_33wOv8680NBme44lbCP3007sQGoFXpApsQZPbM1ug6AwDAQejGNVEq-EuGLmkjSEBlbKReUonoigqyRX-39qFIMrflkEYMahIewWQKUxwFFaR8BLPteRL072BZgqqIBgWG6XDyyONj9Q"
+        }
+    ]
+}
+
+
+#
+# Same as above but defined as an object rather than a package.
+#
+
+example_config := {
+    "jwks_preferred_urls": {
+        "http://localhost": "http://authnz/openid-connect/certs",
+        "https://localhost": "http://authnz/openid-connect/certs"
+    },
+    "jwt_user_field_name": "sub",
+    "jwks": {
+        "keys": [
+            {
+                "p": "8ybS9TowEW0Y0xHpGBm7LGLoc5u8IF-EkuTFdFZ4DchkeFL1M0ditEJEUV7OlKWErxwRGWo6bA7rLmNA8URZZl_SlSYgWcDeKwHwGqrMXgTydzflYxRmS8azenSoXkiDxFE2Y5psq-6mXmlNYlimV0b7jIylgUUtRX1DAzI42fc",
+                "kty": "RSA",
+                "q": "tXKzhk6uYZoL8bkpVrp0xouyhWhgdAcXN5vDlx98aojbD4DkFj4Zd7_Utl9s5HWYEMJPvMTiYUDaJdkeSDBrmA4OH_4QS5R1DqVvBBMq3JJXvVzaZox7ysWXPeEnNXcYFK_qhtnFHN-ztTWk-WmcWaU-nfgg5WEwfrlRyLTD1nM",
+                "d": "M01swzjoerZOvgl0pzAMF-oFloXvxdKPl7BRybqyv1NpVPEU9MfgM3eegNXHl4YBsq3zvgeXAqWDGuxCw23Vn0NtNqTxud4NIb3JI1S42Ez8m8SXvrsphXLWNQ-AT0QO10aa6S9MVKDHtXzw5LcFj39Hz6Z50Pw9L6rYReRkJF3sKJDv9mUjT9unobgHlnc99HQ-XB9r2md0WwdZI6COXAMT32Fgb9ZhBrq8VyhRiZLje7zmiPqYaB5XQKq6mJLhq26yvZ0leQw7DGVZ0Ot9FpdQky3_T80zhXxYi1-6-dttVhdlRGFsAjjXLPtbWhVTObDDKlcfzC7PWZkJhhO7_Q",
+                "e": "AQAB",
+                "use": "sig",
+                "kid": "k1",
+                "qi": "L2QvQX9uB1anD09Ai0ANKhAeWkRbFKRBBLSaCmV9ZteQeHuG_HUEdZp5NSzg0B4yySLsgT37-1Yc0PZNHWDWltIi7PlwpSiTuDpXRHHQlZOwfLKnu40JtJWgIw8e_yFga5SfcoUuv727GAiONQYXhIKDb1PkpXzEvwQQuoDidVc",
+                "dp": "h7acunj-yUsuNujhRC1gdjbCbXx39U267k44E2YL3g2CXlJXP4bRhbES9qPHA9qagy5UMO5Eq3lsNNj7L26pw2UqYUsFdXMbzb9oJ0o7hSKXvoj5RGLncdX26RthujYZLaLyi4durkwmmb2GjqTSOxaIYntCCTP2P7nZhFgsuSM",
+                "alg": "RS256",
+                "dq": "pVCx3AZHvskZZMysq0YKKvMQXZfxeQUU1CdoloGrW20BGSj3poRBs-blKJvcnHG_cFV5TKWdE7qAhsdAXckv3kO__sn9kr7Zv9ReRzonbPswUWkN2yzXhLFt0IUYsg-lswNsDBzRCDOQieMsQclFGDAD0u1FG3fnNS4nI1P-sZ0",
+                "n": "rFdk9QnnPyQXhPgmHXtF7WupI3aCj-2YVprjEPkra-fPtxKRBjEC0AlDi7BhYilZzcpB2MGKAjzUvfKp7YFwAw7fp6M0fHKRyMtGDCzuu0bv6LX4uLFqLeft8UyjYX1Al3LVmX4VmRxVy88BxFh5H85WMtAOy3JPLYVpf6XZ7fOFEkNyzLY2hYklfsnbvG8ZJyNgAOTSx_33wOv8680NBme44lbCP3007sQGoFXpApsQZPbM1ug6AwDAQejGNVEq-EuGLmkjSEBlbKReUonoigqyRX-39qFIMrflkEYMahIewWQKUxwFFaR8BLPteRL072BZgqqIBgWG6XDyyONj9Q"
+            }
+        ]
+    }
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -1,0 +1,21 @@
+#
+# TODO
+#
+
+package authnz.envopa
+
+import input.attributes.request.http as http_request
+import data.authnz.oidc as oidc
+import data.authnz.rbac as rbac
+
+
+# TODO move out of this package. Ideally authnz should be generic..
+jwks_preferred_urls := {
+    "http://localhost": "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
+}
+
+allow(rbac_db) := user {
+    payload := oidc.claims(http_request, jwks_preferred_urls)
+    user := payload.sub  # TODO make expected user field an input param
+    rbac.check(rbac_db, user, http_request)
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -1,5 +1,5 @@
 #
-# TODO
+# TODO docs
 #
 
 package authnz.envopa
@@ -14,8 +14,8 @@ jwks_preferred_urls := {
     "http://localhost": "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
 }
 
-allow(rbac_db) := user {
+allow(rbac_db, jwt_user_field_name) := user {
     payload := oidc.claims(http_request, jwks_preferred_urls)
-    user := payload.sub  # TODO make expected user field an input param
+    user := payload[jwt_user_field_name]
     rbac.check(rbac_db, user, http_request)
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -9,8 +9,8 @@ import data.authnz.oidc as oidc
 import data.authnz.rbac as rbac
 
 
-allow(rbac_db, jwt_user_field_name, jwks_preferred_urls) := user {
-    payload := oidc.claims(http_request, jwks_preferred_urls)
-    user := payload[jwt_user_field_name]
+allow(rbac_db, config) := user {
+    payload := oidc.claims(http_request, config)
+    user := payload[config.jwt_user_field_name]
     rbac.check(rbac_db, user, http_request)
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -9,12 +9,7 @@ import data.authnz.oidc as oidc
 import data.authnz.rbac as rbac
 
 
-# TODO move out of this package. Ideally authnz should be generic..
-jwks_preferred_urls := {
-    "http://localhost": "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
-}
-
-allow(rbac_db, jwt_user_field_name) := user {
+allow(rbac_db, jwt_user_field_name, jwks_preferred_urls) := user {
     payload := oidc.claims(http_request, jwks_preferred_urls)
     user := payload[jwt_user_field_name]
     rbac.check(rbac_db, user, http_request)

--- a/deployment/mesh-infra/security/opa/rego/authnz/http.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/http.rego
@@ -1,0 +1,23 @@
+#
+# Rules for defining RBAC REST policies.
+#
+
+package authnz.http
+
+
+# HTTP methods to use for policy definitions.
+get := "GET"
+head := "HEAD"
+options := "OPTIONS"
+put := "PUT"
+patch := "PATCH"
+post := "POST"
+delete := "DELETE"
+trace := "TRACE"
+connect := "CONNECT"
+
+# Common HTTP method sets used for permission assignment.
+read := { get, head, options }
+write := { put, patch, post, delete }
+read_n_write := read | write
+do_anything := read_n_write | { trace, connect }

--- a/deployment/mesh-infra/security/opa/rego/authnz/http_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/http_test.rego
@@ -1,0 +1,20 @@
+package authnz.http
+
+test_read_set {
+    read == { "GET", "HEAD", "OPTIONS" }
+}
+
+test_write_set {
+    write == { "PUT", "PATCH", "POST", "DELETE" }
+}
+
+test_read_n_write_set {
+    read_n_write ==
+        { "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE" }
+}
+
+test_do_anything_set {
+    do_anything ==
+        { "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE",
+          "TRACE", "CONNECT" }
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc.rego
@@ -1,0 +1,178 @@
+#
+# TODO docs
+#
+
+package authnz.oidc
+
+
+# Verify the JWT token and extract its payload. Expect the token to be
+# in the "Authorization" header as a "Bearer" token. Check all of the
+# statements below are true:
+#
+# * the algo in the header is the same that was used to sign the token;
+# * the token signature is valid;
+# * there's an `exp` field in the payload holding a valid date `d`;
+# * `d` is in the future.
+#
+# Plus, if there's an `nbf` field in the payload, check it has a valid
+# date in the past.
+#
+# Automatically download issuer keys and cache them for a day.
+# If `jwks_preferred_urls` has a key equal to the token issuer's base
+# URL (scheme and authority, e.g. http://my.host), use the correspondig
+# URL value to download the JWKS object. For instance, if
+#   jwt.payload.iss = https://keycloak.external/realms/master
+#   jwks_preferred_urls["https://keycloak.external"] =
+#       http://kc.internal/realms/master/protocol/openid-connect/certs
+# then use this ^ URL to download the JWKS.
+# Otherwise, use the issuer's OIDC well-known config to find out where
+# to download the JWKS from.
+# Notice the `jwks_preferred_urls` can be useful if you want to test
+# with `localhost` or if you want to call your own issuer using an
+# internal cluster address.
+#
+# Params
+# - request. An object containing the HTTP request headers in an object
+#   map called `headers`. Typically, when using the OPA Envoy plugin, you'd
+#   pass in `input.attributes.request.http` for the request param.
+# - jwks_preferred_urls. An map (object) where each key is an issuer URL
+#   and the key's corresponding value is the absolute URL where the issuer
+#   makes the JWKS object available for download. The key URL must contain
+#   only the scheme and authority---e.g. http://my.host, http://my.host:8080.
+claims(request, jwks_preferred_urls) := payload {
+    token := bearer_token(request)
+    [_, p, _] := io.jwt.decode(token)
+    jwks := token_jwks(p, jwks_preferred_urls)
+    payload := token_payload(token, jwks)
+}
+
+# Verify the JWT token and extract its payload. Check all of the
+# statements below are true:
+#
+# * the algo in the header is the same that was used to sign the token;
+# * the token signature is valid;
+# * there's an `exp` field in the payload holding a valid date `d`;
+# * `d` is in the future.
+#
+# Plus, if there's an `nbf` field in the payload, check it has a valid
+# date in the past.
+#
+# Params
+# - token. The JWT token to verify and extract the payload from.
+# - jwks. The key set containing the key the issuer makes available to
+#   verify the token signature. This is a JWKS JSON object typically
+#   retrieved from a URL discovered through the issuer's well-known
+#   OIDC config endpoint.
+token_payload(token, jwks) := payload {
+    [h, _, _] := io.jwt.decode(token)
+    [valid, header, payload] := io.jwt.decode_verify(token, {
+        "alg": h.alg,
+        "cert": jwks
+    })
+
+    # Assert `valid` is `true`.
+    valid
+
+    # Assert there's an `exp` field in the payload.
+    # If true, then `decode_verify` must've checked `exp`'s value is a date
+    # in the future. We need this since if `exp` isn't there, `decode_verify`
+    # sets `valid` to `true`.
+    payload.exp
+}
+
+# Extract the Bearer token from the HTTP request if present, otherwise
+# set it to `undefined`.
+# The request param must be an object containing the HTTP request headers
+# in an object map called `headers`. Typically, when using the OPA Envoy
+# plugin, you'd pass in `input.attributes.request.http` for the request
+# param.
+bearer_token(request) := token {
+    auth := request.headers.authorization
+    startswith(auth, "Bearer ")
+    token := substring(auth, count("Bearer "), -1)
+}
+
+# Fetch the token issuer's keys used to sign JWTs.
+# If there's a preferred URL configured for the token issuer, use that
+# URL to download the JWKS object containing the keys.
+# Expect the `token_payload` param to contain the standard `iss` claim
+# with the token issuer's URL. If the `url_lookup` params has a key equal
+# to that URL's base (scheme and authority, e.g. http://my.host:8080),
+# use the correspondig URL value to download the JWKS object. For instance,
+# if
+#   token_payload.iss = https://keycloak.external/realms/master
+#   url_lookup["https://keycloak.external"] =
+#       http://kc.internal/realms/master/protocol/openid-connect/certs
+# then use this ^ URL to download the JWKS.
+token_jwks(token_payload, url_lookup) = jwks {
+    url := preferred_token_jwks_url(token_payload, url_lookup)
+    print("Downloading JWKS for: ", token_payload.iss,
+          " from preferred JWKS URL: ", url)
+    jwks := fetch_token_jwks(url)
+}
+
+# Fetch the token issuer's keys for JWT validation.
+# If there's no preferred URL configured in `url_lookup`, then use the
+# issuer's OIDC well-known config to find out where to download the JWKS
+# from.
+token_jwks(token_payload, url_lookup) = jwks {
+    not preferred_token_jwks_url(token_payload, url_lookup)
+
+    print("Fetching JWKS for: ", token_payload.iss,
+          ", using JWKS URL from well-known OIDC config")
+    well_known_oidc_url := token_issuer_config_url(token_payload)
+    url := fetch_token_issuer_jwks_url(well_known_oidc_url)
+    print("JWKS URL: ", url)
+
+    jwks := fetch_token_jwks(url)
+}
+
+# Extract scheme and authority from `token_payload` and use it as a
+# key to look up the preferred JWKS download URL in the `url_lookup`
+# map.
+preferred_token_jwks_url(token_payload, url_lookup) := url {
+    base_url := regex.find_n("^[^:]+://[^/]+", token_payload.iss, 1)[_]
+    url := url_lookup[base_url]
+}
+
+# Use `token_payload.iss` as a base URL to build the well-known OIDC
+# config URL.
+token_issuer_config_url(token_payload) := url {
+    config_path := ".well-known/openid-configuration"
+    url := concat("/", [token_payload.iss, config_path])
+}
+
+# Fetch the token issuer's absolute URL where the issuer makes token
+# validation keys available.
+# Retrieve the issuer's well-known OIDC config first, then return the
+# `jwks_uri` field of that config object. Cache the config for a day.
+# The `well_known_oidc_url` param is the absolute URL of the issuer's
+# well-known OIDC config endpoint, e.g.
+# https://my.keycloak/realms/master/.well-known/openid-configuration
+fetch_token_issuer_jwks_url(well_known_oidc_url) := url {
+    response := http.send(
+        {
+            "url": well_known_oidc_url,
+            "method": "GET",
+            "force_cache": true,
+            "force_cache_duration_seconds": 86400
+        }
+    )
+    url := response.body.jwks_uri
+}
+
+# Fetch the keys the token issuer makes available to verify tokens.
+# Cache them for one day.
+# The `url` param is the absolute URL of the issuer's JWKS endpoint, e.g.
+# https://my.keycloak/realms/master/protocol/openid-connect/certs.
+fetch_token_jwks(url) := jwks {
+    response := http.send(
+        {
+            "url": url,
+            "method": "GET",
+            "force_cache": true,
+            "force_cache_duration_seconds": 86400
+        }
+    )
+    jwks := response.body
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_jwt_gen_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_jwt_gen_test.rego
@@ -1,0 +1,64 @@
+#
+# Test utils to generate JWTs.
+#
+
+package authnz.oidc
+
+
+# RSA keys and JWKs generated on https://mkjwk.org/
+# using the parameters below
+#
+#   Key Size         = 2048
+#   Key Use          = Signature
+#   Algorithm        = RS256: RSASSA-PKCS1-v1_5 using SHA-256
+#   Key ID - Specify = k1
+#   Show X.509       = Yes
+
+rsa_pub_key_jwk := {
+    "kty": "RSA",
+    "e": "AQAB",
+    "use": "sig",
+    "kid": "k1",
+    "alg": "RS256",
+    "n": "rFdk9QnnPyQXhPgmHXtF7WupI3aCj-2YVprjEPkra-fPtxKRBjEC0AlDi7BhYilZzcpB2MGKAjzUvfKp7YFwAw7fp6M0fHKRyMtGDCzuu0bv6LX4uLFqLeft8UyjYX1Al3LVmX4VmRxVy88BxFh5H85WMtAOy3JPLYVpf6XZ7fOFEkNyzLY2hYklfsnbvG8ZJyNgAOTSx_33wOv8680NBme44lbCP3007sQGoFXpApsQZPbM1ug6AwDAQejGNVEq-EuGLmkjSEBlbKReUonoigqyRX-39qFIMrflkEYMahIewWQKUxwFFaR8BLPteRL072BZgqqIBgWG6XDyyONj9Q"
+}
+
+rsa_key_pair_jwk := {
+    "p": "8ybS9TowEW0Y0xHpGBm7LGLoc5u8IF-EkuTFdFZ4DchkeFL1M0ditEJEUV7OlKWErxwRGWo6bA7rLmNA8URZZl_SlSYgWcDeKwHwGqrMXgTydzflYxRmS8azenSoXkiDxFE2Y5psq-6mXmlNYlimV0b7jIylgUUtRX1DAzI42fc",
+    "kty": "RSA",
+    "q": "tXKzhk6uYZoL8bkpVrp0xouyhWhgdAcXN5vDlx98aojbD4DkFj4Zd7_Utl9s5HWYEMJPvMTiYUDaJdkeSDBrmA4OH_4QS5R1DqVvBBMq3JJXvVzaZox7ysWXPeEnNXcYFK_qhtnFHN-ztTWk-WmcWaU-nfgg5WEwfrlRyLTD1nM",
+    "d": "M01swzjoerZOvgl0pzAMF-oFloXvxdKPl7BRybqyv1NpVPEU9MfgM3eegNXHl4YBsq3zvgeXAqWDGuxCw23Vn0NtNqTxud4NIb3JI1S42Ez8m8SXvrsphXLWNQ-AT0QO10aa6S9MVKDHtXzw5LcFj39Hz6Z50Pw9L6rYReRkJF3sKJDv9mUjT9unobgHlnc99HQ-XB9r2md0WwdZI6COXAMT32Fgb9ZhBrq8VyhRiZLje7zmiPqYaB5XQKq6mJLhq26yvZ0leQw7DGVZ0Ot9FpdQky3_T80zhXxYi1-6-dttVhdlRGFsAjjXLPtbWhVTObDDKlcfzC7PWZkJhhO7_Q",
+    "e": "AQAB",
+    "use": "sig",
+    "kid": "k1",
+    "qi": "L2QvQX9uB1anD09Ai0ANKhAeWkRbFKRBBLSaCmV9ZteQeHuG_HUEdZp5NSzg0B4yySLsgT37-1Yc0PZNHWDWltIi7PlwpSiTuDpXRHHQlZOwfLKnu40JtJWgIw8e_yFga5SfcoUuv727GAiONQYXhIKDb1PkpXzEvwQQuoDidVc",
+    "dp": "h7acunj-yUsuNujhRC1gdjbCbXx39U267k44E2YL3g2CXlJXP4bRhbES9qPHA9qagy5UMO5Eq3lsNNj7L26pw2UqYUsFdXMbzb9oJ0o7hSKXvoj5RGLncdX26RthujYZLaLyi4durkwmmb2GjqTSOxaIYntCCTP2P7nZhFgsuSM",
+    "alg": "RS256",
+    "dq": "pVCx3AZHvskZZMysq0YKKvMQXZfxeQUU1CdoloGrW20BGSj3poRBs-blKJvcnHG_cFV5TKWdE7qAhsdAXckv3kO__sn9kr7Zv9ReRzonbPswUWkN2yzXhLFt0IUYsg-lswNsDBzRCDOQieMsQclFGDAD0u1FG3fnNS4nI1P-sZ0",
+    "n": "rFdk9QnnPyQXhPgmHXtF7WupI3aCj-2YVprjEPkra-fPtxKRBjEC0AlDi7BhYilZzcpB2MGKAjzUvfKp7YFwAw7fp6M0fHKRyMtGDCzuu0bv6LX4uLFqLeft8UyjYX1Al3LVmX4VmRxVy88BxFh5H85WMtAOy3JPLYVpf6XZ7fOFEkNyzLY2hYklfsnbvG8ZJyNgAOTSx_33wOv8680NBme44lbCP3007sQGoFXpApsQZPbM1ug6AwDAQejGNVEq-EuGLmkjSEBlbKReUonoigqyRX-39qFIMrflkEYMahIewWQKUxwFFaR8BLPteRL072BZgqqIBgWG6XDyyONj9Q"
+}
+
+jwks_tasty_config := {
+    "keys": [
+        rsa_pub_key_jwk
+        # ^ notice Rego will blow up if you use rsa_key_pair_jwk instead.
+        # See: https://github.com/open-policy-agent/opa/issues/6283
+        # In practice this isn't an issue b/c the issuer will never include
+        # the private key in its well-known JWKs. It's just annoying for
+        # testing as we need to generate an extra object.
+    ]
+}
+
+
+generate_tasty_token(payload) := jwt {
+    header := {
+        "alg": "RS256",
+        "kid": "k1",
+        "typ": "JWT"
+    }
+    jwt := io.jwt.encode_sign(header, payload, rsa_key_pair_jwk)
+}
+
+make_bearer_auth(jwt) := auth {
+    auth := sprintf("Bearer %s", [jwt])
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
@@ -114,4 +114,41 @@ test_extract_token_payload_with_nbf_in_the_future {
     not token_payload(token, jwks_tasty_config)
 }
 
-# TODO test claims functions
+test_claims_with_static_jwks {
+    config := {
+        "jwks": jwks_tasty_config
+    }
+    payload := {
+        "iss": "me",
+        "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
+    }
+    token := generate_tasty_token(payload)
+    request := {
+        "headers": {
+            "authorization": make_bearer_auth(token)
+        }
+    }
+    payload == claims(request, config)
+}
+
+test_claims_with_dynamic_jwks {
+    config := {
+        "jwks_preferred_urls": {
+            "http://mock": "http://mock/jwks"
+        }
+    }
+    payload := {
+        "iss": "http://mock",
+        "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
+    }
+    token := generate_tasty_token(payload)
+    request := {
+        "headers": {
+            "authorization": make_bearer_auth(token)
+        }
+    }
+    extracted_payload := claims(request, config)
+                         with data.authnz.oidc.fetch_token_jwks as jwks_tasty_config
+
+    payload == extracted_payload
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
@@ -55,21 +55,22 @@ test_token_issuer_config_url_2 {
     got == want
 }
 
-# NOTE. This test needs the Teadal VM running on localhost.
 test_token_jwks_preferred_url {
     token_payload := {"iss": "http://localhost/keycloak/realms/master"}
     url_lookup := {
         "http://localhost": "http://localhost/keycloak/realms/master/protocol/openid-connect/certs"
     }
     jwks := token_jwks(token_payload, url_lookup)
+            with data.authnz.oidc.fetch_token_jwks as jwks_tasty_config
     jwks.keys  # assert present
 }
 
-# NOTE. This test needs the Teadal VM running on localhost.
 test_token_jwks_canonical_url {
     token_payload := {"iss": "http://localhost/keycloak/realms/master"}
     url_lookup := { }
     jwks := token_jwks(token_payload, url_lookup)
+            with data.authnz.oidc.fetch_token_issuer_jwks_url as "mock"
+            with data.authnz.oidc.fetch_token_jwks as jwks_tasty_config
     jwks.keys  # assert present
 }
 

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
@@ -1,0 +1,78 @@
+package authnz.oidc
+
+
+test_preferred_token_jwks_url_1 {
+    want := "http://keycloak/realms/master/protocol/openid-connect/certs"
+    token_payload := {"iss": "http://localhost/keycloak/realms/master"}
+    url_lookup := {
+        "http://localhost": want
+    }
+    got := preferred_token_jwks_url(token_payload, url_lookup)
+    got == want
+}
+
+test_preferred_token_jwks_url_2 {
+    want := "http://oi.dc/certs"
+    token_payload := {"iss": "http://localhost:8080"}
+    url_lookup := {
+        "http://localhost:8080": want
+    }
+    got := preferred_token_jwks_url(token_payload, url_lookup)
+    got == want
+}
+
+test_preferred_token_jwks_url_3 {
+    want := "http://oi.dc/certs"
+    token_payload := {"iss": "http://localhost:8080/"}
+    url_lookup := {
+        "http://localhost:8080": want
+    }
+    got := preferred_token_jwks_url(token_payload, url_lookup)
+    got == want
+}
+
+test_preferred_token_jwks_url_4 {
+    want := "http://oi.dc/certs"
+    token_payload := {"iss": "http://localhost:8080/p/q?v=1"}
+    url_lookup := {
+        "http://localhost:8080": want
+    }
+    got := preferred_token_jwks_url(token_payload, url_lookup)
+    got == want
+}
+
+test_token_issuer_config_url_1 {
+    want := "https://key.cloak/realms/master/.well-known/openid-configuration"
+    token_payload := {"iss": "https://key.cloak/realms/master"}
+    got := token_issuer_config_url(token_payload)
+    got == want
+}
+
+test_token_issuer_config_url_2 {
+    want := "https://key.cloak/realms/master/.well-known/openid-configuration"
+    token_payload := {"iss": "https://key.cloak/realms/master/"}
+    got := token_issuer_config_url(token_payload)
+    got == want
+    # TODO fix double slash
+    # got: https://key.cloak/realms/master//.well-known/openid-configuration
+}
+
+# NOTE. This test needs the Teadal VM running on localhost.
+test_token_jwks_preferred_url {
+    token_payload := {"iss": "http://localhost/keycloak/realms/master"}
+    url_lookup := {
+        "http://localhost": "http://localhost/keycloak/realms/master/protocol/openid-connect/certs"
+    }
+    jwks := token_jwks(token_payload, url_lookup)
+    jwks.keys  # assert present
+}
+
+# NOTE. This test needs the Teadal VM running on localhost.
+test_token_jwks_canonical_url {
+    token_payload := {"iss": "http://localhost/keycloak/realms/master"}
+    url_lookup := { }
+    jwks := token_jwks(token_payload, url_lookup)
+    jwks.keys  # assert present
+}
+
+# TODO test token_payload and claims functions

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -1,0 +1,44 @@
+#
+# Functions to query and evaluate RBAC REST policies.
+#
+# All the functions below take a RBAC DB and a user as input. The RBAC DB
+# must be in the format specified in RBAC DB test. The user is a username
+# string which may or may not be one of the usernames defined in the RBAC
+# DB.
+#
+
+package authnz.rbac
+
+
+# Find all the roles associated to the given user.
+user_roles(rbac_db, user) := roles {
+    roles := rbac_db.user_to_roles[user]
+}
+
+# Find all the permissions associated the the given role.
+role_perms(rbac_db, role) := perms {
+    perms := rbac_db.role_to_perms[role]
+}
+
+# Find all the permissions associated the the given user.
+# TODO. broken at the mo. See test_user_perms:
+#   eval_conflict_error:
+#     functions must not produce multiple outputs for same inputs
+user_perms(rbac_db, user) := perms {
+    role := user_roles(rbac_db, user)[_]
+    perms := role_perms(rbac_db, role)[_]
+}
+
+# Check the given user is allowed to carry out the requested operation
+# (HTTP method) on the target resource.
+#
+# The request param must be an object containing `method` and `path`
+# fields. `method` is the HTTP request method whereas `path` is the
+# HTTP request path. Typically, when using the OPA Envoy plugin, you'd
+# pass in `input.attributes.request.http` for the request param.
+check(rbac_db, user, request) {
+    role := rbac_db.user_to_roles[user][_]
+    perm := rbac_db.role_to_perms[role][_]
+    perm.methods[_] == request.method
+    regex.match(perm.url_regex, request.path)
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -21,12 +21,10 @@ role_perms(rbac_db, role) := perms {
 }
 
 # Find all the permissions associated the the given user.
-# TODO. broken at the mo. See test_user_perms:
-#   eval_conflict_error:
-#     functions must not produce multiple outputs for same inputs
 user_perms(rbac_db, user) := perms {
-    role := user_roles(rbac_db, user)[_]
-    perms := role_perms(rbac_db, role)[_]
+    roles := user_roles(rbac_db, user)
+    perm_sets := { rbac_db.role_to_perms[k] | roles[k] }
+    perms := union(perm_sets)
 }
 
 # Check the given user is allowed to carry out the requested operation

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -1,0 +1,87 @@
+package authnz.rbac
+
+import data.authnz.http as http
+import data.authnz.rbacdb as rbac_db
+
+
+test_role_lookup {
+    user_roles(rbac_db, "jeejee") == { "product_owner", "product_consumer" }
+    user_roles(rbac_db, "sebs") == { "product_consumer" }
+}
+
+test_role_perms {
+    role_perms(rbac_db, "product_owner") == {
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/httpbin/anything/.*"
+        }
+    }
+    role_perms(rbac_db, "product_consumer") == {
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    }
+}
+
+test_user_perms {
+    user_perms(rbac_db, "jeejee") == {
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    }
+    user_perms(rbac_db, "sebs") == {
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    }
+}
+
+assert_user_can_do_anything_on_path(user, path) {
+    check(rbac_db, user, {"method": "GET", "path": path})
+    check(rbac_db, user, {"method": "HEAD", "path": path})
+    check(rbac_db, user, {"method": "OPTIONS", "path": path})
+    check(rbac_db, user, {"method": "PUT", "path": path})
+    check(rbac_db, user, {"method": "POST", "path": path})
+    check(rbac_db, user, {"method": "PATCH", "path": path})
+    check(rbac_db, user, {"method": "DELETE", "path": path})
+    check(rbac_db, user, {"method": "CONNECT", "path": path})
+    check(rbac_db, user, {"method": "TRACE", "path": path})
+}
+
+assert_user_can_only_read_path(user, path) {
+    check(rbac_db, user, {"method": "GET", "path": path})
+    check(rbac_db, user, {"method": "HEAD", "path": path})
+    check(rbac_db, user, {"method": "OPTIONS", "path": path})
+    not check(rbac_db, user, {"method": "PUT", "path": path})
+    not check(rbac_db, user, {"method": "POST", "path": path})
+    not check(rbac_db, user, {"method": "PATCH", "path": path})
+    not check(rbac_db, user, {"method": "DELETE", "path": path})
+    not check(rbac_db, user, {"method": "CONNECT", "path": path})
+    not check(rbac_db, user, {"method": "TRACE", "path": path})
+}
+
+test_check_perms {
+    assert_user_can_do_anything_on_path("jeejee", "/httpbin/anything/")
+    assert_user_can_only_read_path("sebs", "/httpbin/anything/")
+    assert_user_can_only_read_path("jeejee", "/httpbin/get")
+    assert_user_can_only_read_path("sebs", "/httpbin/get")
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
@@ -13,7 +13,7 @@ product_consumer := "product_consumer"
 
 # Map each role to a set of permission objects.
 # Each permission object specifies a set of allowed HTTP methods for
-# the Web resources identitified by the URLs matching the given regex.
+# the Web resources identified by the URLs matching the given regex.
 role_to_perms := {
     product_owner: {
         {

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
@@ -1,0 +1,40 @@
+#
+# Test RBAC DB.
+#
+
+package authnz.rbacdb
+
+import data.authnz.http as http
+
+
+# Role defs.
+product_owner := "product_owner"
+product_consumer := "product_consumer"
+
+# Map each role to a set of permission objects.
+# Each permission object specifies a set of allowed HTTP methods for
+# the Web resources identitified by the URLs matching the given regex.
+role_to_perms := {
+    product_owner: {
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/httpbin/anything/.*"
+        }
+    },
+    product_consumer: {
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    }
+}
+
+# Map each user to their roles.
+user_to_roles := {
+    "jeejee": { product_owner, product_consumer },
+    "sebs": { product_consumer }
+}

--- a/deployment/mesh-infra/security/opa/rego/config/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/config/oidc.rego
@@ -1,6 +1,9 @@
+#
+# Base `authnz` config.
+# See `authnz.config` for explanations.
+#
 package config.oidc
 
-# TODO explain this!
 
 internal_keycloak_jwks_url := "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
 

--- a/deployment/mesh-infra/security/opa/rego/config/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/config/oidc.rego
@@ -1,0 +1,12 @@
+package config.oidc
+
+# TODO explain this!
+
+internal_keycloak_jwks_url := "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
+
+jwks_preferred_urls := {
+    "http://localhost": internal_keycloak_jwks_url,
+    "https://localhost": internal_keycloak_jwks_url
+}
+
+jwt_user_field_name := "sub"

--- a/deployment/mesh-infra/security/opa/rego/config/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/config/oidc.rego
@@ -9,4 +9,4 @@ jwks_preferred_urls := {
     "https://localhost": internal_keycloak_jwks_url
 }
 
-jwt_user_field_name := "sub"
+jwt_user_field_name := "email"

--- a/deployment/mesh-infra/security/opa/rego/config/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/config/oidc.rego
@@ -5,7 +5,7 @@
 package config.oidc
 
 
-internal_keycloak_jwks_url := "http://keycloak:8080/keycloak/realms/master/protocol/openid-connect/certs"
+internal_keycloak_jwks_url := "http://keycloak:8080/keycloak/realms/teadal/protocol/openid-connect/certs"
 
 jwks_preferred_urls := {
     "http://localhost": internal_keycloak_jwks_url,

--- a/deployment/mesh-infra/security/opa/rego/httpbin/istio-example-input.json
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/istio-example-input.json
@@ -1,0 +1,60 @@
+{
+    "input": {
+        "attributes": {
+            "destination": {
+                "address": {
+                    "socketAddress": {
+                        "address": "10.1.0.215",
+                        "portValue": 8080
+                    }
+                }
+            },
+            "metadataContext": {},
+            "request": {
+                "http": {
+                    "headers": {
+                        ":authority": "localhost",
+                        ":method": "GET",
+                        ":path": "/httpbin/get",
+                        ":scheme": "http",
+                        "accept": "*/*",
+                        "user-agent": "curl/7.88.1",
+                        "x-envoy-decorator-operation": "httpbin.default.svc.cluster.local:8000/httpbin/*",
+                        "x-envoy-internal": "true",
+                        "x-envoy-peer-metadata": "ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKHAoMSU5TVEFOQ0VfSVBTEgwaCjEwLjEuMC4yMTUKGQoNSVNUSU9fVkVSU0lPThIIGgYxLjE4LjAKnAMKBkxBQkVMUxKRAyqOAwodCgNhcHASFhoUaXN0aW8taW5ncmVzc2dhdGV3YXkKEwoFY2hhcnQSChoIZ2F0ZXdheXMKFAoIaGVyaXRhZ2USCBoGVGlsbGVyCjYKKWluc3RhbGwub3BlcmF0b3IuaXN0aW8uaW8vb3duaW5nLXJlc291cmNlEgkaB3Vua25vd24KGQoFaXN0aW8SEBoOaW5ncmVzc2dhdGV3YXkKGQoMaXN0aW8uaW8vcmV2EgkaB2RlZmF1bHQKMAobb3BlcmF0b3IuaXN0aW8uaW8vY29tcG9uZW50EhEaD0luZ3Jlc3NHYXRld2F5cwoSCgdyZWxlYXNlEgcaBWlzdGlvCjkKH3NlcnZpY2UuaXN0aW8uaW8vY2Fub25pY2FsLW5hbWUSFhoUaXN0aW8taW5ncmVzc2dhdGV3YXkKLwojc2VydmljZS5pc3Rpby5pby9jYW5vbmljYWwtcmV2aXNpb24SCBoGbGF0ZXN0CiIKF3NpZGVjYXIuaXN0aW8uaW8vaW5qZWN0EgcaBWZhbHNlChoKB01FU0hfSUQSDxoNY2x1c3Rlci5sb2NhbAovCgROQU1FEicaJWlzdGlvLWluZ3Jlc3NnYXRld2F5LTU2NDQ0Njg3NzQtYzJuaGwKGwoJTkFNRVNQQUNFEg4aDGlzdGlvLXN5c3RlbQpdCgVPV05FUhJUGlJrdWJlcm5ldGVzOi8vYXBpcy9hcHBzL3YxL25hbWVzcGFjZXMvaXN0aW8tc3lzdGVtL2RlcGxveW1lbnRzL2lzdGlvLWluZ3Jlc3NnYXRld2F5ChcKEVBMQVRGT1JNX01FVEFEQVRBEgIqAAonCg1XT1JLTE9BRF9OQU1FEhYaFGlzdGlvLWluZ3Jlc3NnYXRld2F5",
+                        "x-envoy-peer-metadata-id": "router~10.1.0.215~istio-ingressgateway-5644468774-c2nhl.istio-system~istio-system.svc.cluster.local",
+                        "x-forwarded-for": "10.1.0.1",
+                        "x-forwarded-proto": "http",
+                        "x-request-id": "35c68889-aef3-94a5-8e49-ea9e226ad77c"
+                    },
+                    "host": "localhost",
+                    "id": "2059982201333860156",
+                    "method": "GET",
+                    "path": "/httpbin/get",
+                    "protocol": "HTTP/1.1",
+                    "scheme": "http"
+                },
+                "time": "2023-09-22T16:57:58.257964Z"
+            },
+            "source": {
+                "address": {
+                    "socketAddress": {
+                        "address": "10.1.0.1",
+                        "portValue": 50108
+                    }
+                }
+            }
+        },
+        "parsed_body": null,
+        "parsed_path": [
+            "httpbin",
+            "get"
+        ],
+        "parsed_query": {},
+        "truncated_body": false,
+        "version": {
+            "encoding": "protojson",
+            "ext_authz": "v3"
+        }
+    }
+}

--- a/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
@@ -1,0 +1,43 @@
+#
+# Example RBAC DB.
+# Replace with yours or import is as an external data bundle---e.g.
+# by making OPA download a tarball from a Web server or by linking
+# it from a local disk.
+#
+
+package httpbin.rbacdb
+
+import data.authnz.http as http
+
+
+# Role defs.
+product_owner := "product_owner"
+product_consumer := "product_consumer"
+
+# Map each role to a list of permission objects.
+# Each permission object specifies a set of allowed HTTP methods for
+# the Web resources identitified by the URLs matching the given regex.
+role_to_perms := {
+    product_owner: [
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/httpbin/anything/.*"
+        }
+    ],
+    product_consumer: [
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    ]
+}
+
+# Map each user to their roles.
+user_to_roles := {
+    "jeejee": [ product_owner, product_consumer ],
+    "sebs": [ product_consumer ]
+}

--- a/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
@@ -38,6 +38,6 @@ role_to_perms := {
 
 # Map each user to their roles.
 user_to_roles := {
-    "jeejee": [ product_owner, product_consumer ],
-    "sebs": [ product_consumer ]
+    "jeejee@teadal.eu": [ product_owner, product_consumer ],
+    "sebs@teadal.eu": [ product_consumer ]
 }

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
@@ -6,16 +6,14 @@ package httpbin.service
 
 import input.attributes.request.http as http_request
 import data.authnz.envopa as envopa
-import data.config.oidc as config
+import data.config.oidc as oidc_config
 import data.httpbin.rbacdb as rbac_db
 
 
 default allow := false
 
 allow = true {
-    user := envopa.allow(rbac_db,
-                         config.jwt_user_field_name,
-                         config.jwks_preferred_urls)
+    user := envopa.allow(rbac_db, oidc_config)
 
     # Put below this line any service-specific checks on e.g. http_request
 

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
@@ -5,10 +5,18 @@
 package httpbin.service
 
 import input.attributes.request.http as http_request
+import data.authnz.envopa as envopa
+import data.config.oidc as config
+import data.httpbin.rbacdb as rbac_db
 
 
 default allow := false
 
 allow = true {
-    regex.match("^/httpbin/.*", http_request.path)
+    user := envopa.allow(rbac_db,
+                         config.jwt_user_field_name,
+                         config.jwks_preferred_urls)
+
+    # Put below this line any service-specific checks on e.g. http_request
+
 }

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
@@ -1,0 +1,14 @@
+#
+# Placeholder policy for HttpBin.
+#
+
+package httpbin.service
+
+import input.attributes.request.http as http_request
+
+
+default allow := false
+
+allow = true {
+    regex.match("^/httpbin/.*", http_request.path)
+}

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service_test.rego
@@ -1,0 +1,92 @@
+package httpbin.service
+
+import data.authnz.oidc as oidc
+
+
+jeejees_token := token {
+    payload := {
+        "email": "jeejee@teadal.eu",
+        "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
+    }
+    token := oidc.generate_tasty_token(payload)
+}
+jeejees_auth := oidc.make_bearer_auth(jeejees_token)
+
+sebs_token := token {
+    payload := {
+        "email": "sebs@teadal.eu",
+        "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
+    }
+    token := oidc.generate_tasty_token(payload)
+}
+sebs_auth := oidc.make_bearer_auth(sebs_token)
+
+oidc_config := {
+   "jwt_user_field_name": "email",
+   "jwks": oidc.jwks_tasty_config
+}
+
+make_request(method, path, auth) := envoy_input {
+    envoy_input := {
+        "attributes": {
+            "request": {
+                "http": {
+                    "headers": {
+                        "authorization": auth
+                    },
+                    "method": method,
+                    "path": path
+                }
+            }
+        }
+    }
+}
+
+assert_user_can_do_anything_on_path(path, user_auth) {
+    allow with input as make_request("GET", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("HEAD", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("OPTIONS", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("PUT", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("POST", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("PATCH", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("DELETE", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("CONNECT", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("TRACE", path, user_auth)
+          with data.config.oidc as oidc_config
+}
+
+assert_user_can_only_read_path(path, user_auth) {
+    allow with input as make_request("GET", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("HEAD", path, user_auth)
+          with data.config.oidc as oidc_config
+    allow with input as make_request("OPTIONS", path, user_auth)
+          with data.config.oidc as oidc_config
+    not allow with input as make_request("PUT", path, user_auth)
+              with data.config.oidc as oidc_config
+    not allow with input as make_request("POST", path, user_auth)
+              with data.config.oidc as oidc_config
+    not allow with input as make_request("PATCH", path, user_auth)
+              with data.config.oidc as oidc_config
+    not allow with input as make_request("DELETE", path, user_auth)
+              with data.config.oidc as oidc_config
+    not allow with input as make_request("CONNECT", path, user_auth)
+              with data.config.oidc as oidc_config
+    not allow with input as make_request("TRACE", path, user_auth)
+              with data.config.oidc as oidc_config
+}
+
+test_check_perms {
+    assert_user_can_do_anything_on_path("/httpbin/anything/", jeejees_auth)
+    assert_user_can_only_read_path("/httpbin/anything/", sebs_auth)
+    assert_user_can_only_read_path("/httpbin/get", jeejees_auth)
+    assert_user_can_only_read_path("/httpbin/get", sebs_auth)
+}

--- a/deployment/mesh-infra/security/opa/rego/main.rego
+++ b/deployment/mesh-infra/security/opa/rego/main.rego
@@ -1,0 +1,34 @@
+#
+# Policy decision entry point.
+# Delegate decisions to policies relevant for the request at hand.
+#
+# NOTE OPA hook. The OPA service is configured to evaluate the
+# `allow` expression in this package---i.e. `data.teadal.allow`,
+# see `opa-envoy-plugin.yaml`. If you rename this package or the
+# allow rule below, you'll have to change the pod config in
+# `opa-envoy-plugin.yaml` accordingly.
+#
+package teadal
+
+import data.httpbin.service as httpbin
+import data.minio.service as minio
+
+
+default allow := false
+
+allow {
+    httpbin.allow
+}
+
+# or
+
+allow {
+    minio.allow
+}
+
+# NOTE. These two policies are mutually exclusive. In fact, the
+# httpbin policy denies access if request path doesn't start with
+# "/httpbin/". Likewise the minio policy denies access if the path
+# doesn't start with "/minio/". As a result, the httpbin policy gets
+# to decide how to protect resources under the "/httpbin/" path whereas
+# the minio policy decides about resources under "/minio/".

--- a/deployment/mesh-infra/security/opa/rego/minio/istio-example-input.json
+++ b/deployment/mesh-infra/security/opa/rego/minio/istio-example-input.json
@@ -1,0 +1,60 @@
+{
+    "input": {
+        "attributes": {
+            "destination": {
+                "address": {
+                    "socketAddress": {
+                        "address": "10.1.0.215",
+                        "portValue": 8080
+                    }
+                }
+            },
+            "metadataContext": {},
+            "request": {
+                "http": {
+                    "headers": {
+                        ":authority": "localhost",
+                        ":method": "GET",
+                        ":path": "/minio/",
+                        ":scheme": "http",
+                        "accept": "*/*",
+                        "user-agent": "curl/7.88.1",
+                        "x-envoy-decorator-operation": "minio.minio-operator.svc.cluster.local:80/minio/*",
+                        "x-envoy-internal": "true",
+                        "x-envoy-peer-metadata": "ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKHAoMSU5TVEFOQ0VfSVBTEgwaCjEwLjEuMC4yMTUKGQoNSVNUSU9fVkVSU0lPThIIGgYxLjE4LjAKnAMKBkxBQkVMUxKRAyqOAwodCgNhcHASFhoUaXN0aW8taW5ncmVzc2dhdGV3YXkKEwoFY2hhcnQSChoIZ2F0ZXdheXMKFAoIaGVyaXRhZ2USCBoGVGlsbGVyCjYKKWluc3RhbGwub3BlcmF0b3IuaXN0aW8uaW8vb3duaW5nLXJlc291cmNlEgkaB3Vua25vd24KGQoFaXN0aW8SEBoOaW5ncmVzc2dhdGV3YXkKGQoMaXN0aW8uaW8vcmV2EgkaB2RlZmF1bHQKMAobb3BlcmF0b3IuaXN0aW8uaW8vY29tcG9uZW50EhEaD0luZ3Jlc3NHYXRld2F5cwoSCgdyZWxlYXNlEgcaBWlzdGlvCjkKH3NlcnZpY2UuaXN0aW8uaW8vY2Fub25pY2FsLW5hbWUSFhoUaXN0aW8taW5ncmVzc2dhdGV3YXkKLwojc2VydmljZS5pc3Rpby5pby9jYW5vbmljYWwtcmV2aXNpb24SCBoGbGF0ZXN0CiIKF3NpZGVjYXIuaXN0aW8uaW8vaW5qZWN0EgcaBWZhbHNlChoKB01FU0hfSUQSDxoNY2x1c3Rlci5sb2NhbAovCgROQU1FEicaJWlzdGlvLWluZ3Jlc3NnYXRld2F5LTU2NDQ0Njg3NzQtYzJuaGwKGwoJTkFNRVNQQUNFEg4aDGlzdGlvLXN5c3RlbQpdCgVPV05FUhJUGlJrdWJlcm5ldGVzOi8vYXBpcy9hcHBzL3YxL25hbWVzcGFjZXMvaXN0aW8tc3lzdGVtL2RlcGxveW1lbnRzL2lzdGlvLWluZ3Jlc3NnYXRld2F5ChcKEVBMQVRGT1JNX01FVEFEQVRBEgIqAAonCg1XT1JLTE9BRF9OQU1FEhYaFGlzdGlvLWluZ3Jlc3NnYXRld2F5",
+                        "x-envoy-peer-metadata-id": "router~10.1.0.215~istio-ingressgateway-5644468774-c2nhl.istio-system~istio-system.svc.cluster.local",
+                        "x-forwarded-for": "10.1.0.1",
+                        "x-forwarded-proto": "http",
+                        "x-request-id": "52c3384b-54f2-9817-98dc-d39669ba0da9"
+                    },
+                    "host": "localhost",
+                    "id": "3111837295593477224",
+                    "method": "GET",
+                    "path": "/minio/",
+                    "protocol": "HTTP/1.1",
+                    "scheme": "http"
+                },
+                "time": "2023-09-22T17:06:44.500754Z"
+            },
+            "source": {
+                "address": {
+                    "socketAddress": {
+                        "address": "10.1.0.1",
+                        "portValue": 11721
+                    }
+                }
+            }
+        },
+        "parsed_body": null,
+        "parsed_path": [
+            "minio",
+            ""
+        ],
+        "parsed_query": {},
+        "truncated_body": false,
+        "version": {
+            "encoding": "protojson",
+            "ext_authz": "v3"
+        }
+    }
+}

--- a/deployment/mesh-infra/security/opa/rego/minio/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/minio/service.rego
@@ -1,0 +1,14 @@
+#
+# Placeholder policy for MinIO.
+#
+
+package minio.service
+
+import input.attributes.request.http as http_request
+
+
+default allow := false
+
+allow = true {
+    regex.match("^/minio/.*", http_request.path)
+}

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -13,6 +13,7 @@ the Teadal cluster. Names & versions below.
 * argocd `2.7.6`
 * kustomize `5.0.3`
 * kubernetes-helm `3.11.3`
+* opa `0.53.1`
 * qemu `8.0.0`
 
 Please, like please, install the exact versions and if you do have

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -14,6 +14,7 @@ the Teadal cluster. Names & versions below.
 * kustomize `5.0.3`
 * kubernetes-helm `3.11.3`
 * opa `0.53.1`
+* opa-envoy-plugin `0.53.1`
 * qemu `8.0.0`
 
 Please, like please, install the exact versions and if you do have

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -5,7 +5,9 @@ Dev env
 At the moment, we're using some basic tools to develop and manage
 the Teadal cluster. Names & versions below.
 
+* curl `8.1.1`
 * git `2.40.1`
+* jq `1.6`
 * kubectl `1.27.1`
 * kubectl-directpv `4.0.6`
 * kubectl-minio `5.0.6`

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -23,6 +23,8 @@
         (final: prev: {
           argocd = nixpkgs-unstable.legacyPackages.${system}.argocd;
           istioctl = nixpkgs-unstable.legacyPackages.${system}.istioctl;
+          open-policy-agent =
+            nixpkgs-unstable.legacyPackages.${system}.open-policy-agent;
         })
       ];
     };

--- a/nix/modules/k8s/aarch64.nix
+++ b/nix/modules/k8s/aarch64.nix
@@ -40,14 +40,26 @@ with types;
         sha256 = "sha256-yXkgJW2SQcAFzjmBSAn2qo6O4m5AgMKwiT/LR+dqmzA=";
       };
     };
+    teadal.k8s.aarch64.opaEnvoyPluginImg = mkOption {
+      description = ''
+        Aarch64 OPA Envoy Plugin Docker image. OPA don't release an Aarch64
+        image, so we preload our own custom-built one.
+      '';
+      type = package;
+      default = pkgs.teadal.opa-envoy-plugin-img;
+    };
   };
 
   config = let
     enabled = pkgs.stdenv.isAarch64 && config.teadal.k8s.aarch64.enable;
     corednsImg = config.teadal.k8s.aarch64.corednsImg;
+    opanvoyImg = config.teadal.k8s.aarch64.opaEnvoyPluginImg;
   in (mkIf enabled
   {
-    services.kubernetes.addons.dns.coredns = corednsImg;
+    services.kubernetes = {
+      addons.dns.coredns = corednsImg;
+      kubelet.seedDockerImages = [ opanvoyImg ];
+    };
 
     services.etcd.extraConf = {
       # etcd won't start on aarch64 unless ETCD_UNSUPPORTED_ARCH is

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -9,7 +9,7 @@
   ripgrep, ripgrep-all, mkpasswd, unzip, zip, aria,
 
   git, kubectl, istioctl, argocd, kustomize, kubernetes-helm, open-policy-agent,
-  qemu, nixos-rebuild,
+  qemu, nixos-rebuild, curl, jq,
 
   kubectl-directpv, kubectl-minio,
   opa-envoy-plugin
@@ -46,7 +46,9 @@ rec {
 
   # Tools for K8s stack dev & ops to be installed in dev shells.
   dev = [             # version
+    curl              # 8.1.1    (pkgs = nixos-23.05)
     git               # 2.40.1   (pkgs = nixos-23.05)
+    jq                # 1.6      (pkgs = nixos-23.05)
     kubectl           # 1.27.1   (pkgs = nixos-23.05)
     kustomize         # 5.0.3    (pkgs = nixos-23.05)
     kubernetes-helm   # 3.11.3   (pkgs = nixos-23.05)

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -11,7 +11,8 @@
   git, kubectl, istioctl, argocd, kustomize, kubernetes-helm, open-policy-agent,
   qemu, nixos-rebuild,
 
-  kubectl-directpv, kubectl-minio
+  kubectl-directpv, kubectl-minio,
+  opa-envoy-plugin
 }:
 
 rec {
@@ -50,6 +51,7 @@ rec {
     kustomize         # 5.0.3    (pkgs = nixos-23.05)
     kubernetes-helm   # 3.11.3   (pkgs = nixos-23.05)
     open-policy-agent # 0.53.1   (pkgs = nixos-unstable on 01 Jul 2023)
+    opa-envoy-plugin  # 0.53.1   (pkgs = nixos-23.05)
     qemu              # 8.0.0    (pkgs = nixos-23.05)
     nixos-rebuild
   ] ++ node-cloud;

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -8,7 +8,7 @@
   parted, tcpdump, ldns, nmap, ethtool, tree, bc, lsof, lesspipe,
   ripgrep, ripgrep-all, mkpasswd, unzip, zip, aria,
 
-  git, kubectl, istioctl, argocd, kustomize, kubernetes-helm,
+  git, kubectl, istioctl, argocd, kustomize, kubernetes-helm, open-policy-agent,
   qemu, nixos-rebuild,
 
   kubectl-directpv, kubectl-minio
@@ -44,12 +44,13 @@ rec {
   node = node-cli ++ node-cloud;
 
   # Tools for K8s stack dev & ops to be installed in dev shells.
-  dev = [             # version (pkgs = nixos-23.05)
-    git               # 2.40.1
-    kubectl           # 1.27.1
-    kustomize         # 5.0.3
-    kubernetes-helm   # 3.11.3
-    qemu              # 8.0.0
+  dev = [             # version
+    git               # 2.40.1   (pkgs = nixos-23.05)
+    kubectl           # 1.27.1   (pkgs = nixos-23.05)
+    kustomize         # 5.0.3    (pkgs = nixos-23.05)
+    kubernetes-helm   # 3.11.3   (pkgs = nixos-23.05)
+    open-policy-agent # 0.53.1   (pkgs = nixos-unstable on 01 Jul 2023)
+    qemu              # 8.0.0    (pkgs = nixos-23.05)
     nixos-rebuild
   ] ++ node-cloud;
 

--- a/nix/pkgs/mkSysOutput.nix
+++ b/nix/pkgs/mkSysOutput.nix
@@ -28,6 +28,9 @@ let
   # kubectl-minio = sysPkgs.callPackage ./kubectl-minio/pkg.nix { };
 
   opa-envoy-plugin = sysPkgs.callPackage ./opa-envoy-plugin/pkg.nix { };
+  opa-envoy-plugin-img = sysPkgs.callPackage ./opa-envoy-plugin/docker.nix {
+    inherit opa-envoy-plugin;
+  };
 
   tools = sysPkgs.callPackage ./cli-tools/pkg.nix {
     inherit kubectl-directpv kubectl-minio opa-envoy-plugin;
@@ -36,7 +39,9 @@ let
 in rec {
   packages.${system} =
     tools.shared // (if isLinux then tools.linux else {}) //
-    { inherit kubectl-directpv kubectl-minio opa-envoy-plugin; };
+    { inherit kubectl-directpv kubectl-minio
+              opa-envoy-plugin opa-envoy-plugin-img;
+    };
   defaultPackage.${system} = tools.shared.cli-tools-dev-shell;
 }
 # NOTE

--- a/nix/pkgs/mkSysOutput.nix
+++ b/nix/pkgs/mkSysOutput.nix
@@ -27,14 +27,16 @@ let
   # If you'd rather build from source, use this expression instead:
   # kubectl-minio = sysPkgs.callPackage ./kubectl-minio/pkg.nix { };
 
+  opa-envoy-plugin = sysPkgs.callPackage ./opa-envoy-plugin/pkg.nix { };
+
   tools = sysPkgs.callPackage ./cli-tools/pkg.nix {
-    inherit kubectl-directpv kubectl-minio;
+    inherit kubectl-directpv kubectl-minio opa-envoy-plugin;
   };
 
 in rec {
   packages.${system} =
     tools.shared // (if isLinux then tools.linux else {}) //
-    { inherit kubectl-directpv kubectl-minio; };
+    { inherit kubectl-directpv kubectl-minio opa-envoy-plugin; };
   defaultPackage.${system} = tools.shared.cli-tools-dev-shell;
 }
 # NOTE

--- a/nix/pkgs/opa-envoy-plugin/config.nix
+++ b/nix/pkgs/opa-envoy-plugin/config.nix
@@ -1,5 +1,6 @@
 {
-  gitTag = "v0.53.1-envoy";
-  pkgVer = "0.53.1-envoy";
-  pname  = "opa-envoy-plugin";
+  gitTag  = "v0.53.1-envoy";
+  pkgVer  = "0.53.1-envoy";
+  pname   = "opa-envoy-plugin";
+  imgName = "openpolicyagent/opa";
 }

--- a/nix/pkgs/opa-envoy-plugin/config.nix
+++ b/nix/pkgs/opa-envoy-plugin/config.nix
@@ -1,0 +1,5 @@
+{
+  gitTag = "v0.53.1-envoy";
+  pkgVer = "0.53.1-envoy";
+  pname  = "opa-envoy-plugin";
+}

--- a/nix/pkgs/opa-envoy-plugin/docker.nix
+++ b/nix/pkgs/opa-envoy-plugin/docker.nix
@@ -6,7 +6,7 @@
 let
   cfg = import ./config.nix;
 in dockerTools.buildImage {
-  name = cfg.pname;
+  name = cfg.imgName;
   tag = cfg.pkgVer;
 
   copyToRoot = buildEnv {

--- a/nix/pkgs/opa-envoy-plugin/docker.nix
+++ b/nix/pkgs/opa-envoy-plugin/docker.nix
@@ -1,0 +1,24 @@
+{
+  buildEnv,
+  dockerTools,
+  opa-envoy-plugin
+}:
+let
+  cfg = import ./config.nix;
+in dockerTools.buildImage {
+  name = cfg.pname;
+  tag = cfg.pkgVer;
+
+  copyToRoot = buildEnv {
+    name = "opa-envoy-plugin-image-root";
+    paths = [ opa-envoy-plugin ];
+    pathsToLink = [ "/bin" ];
+  };
+
+  config = {
+    Entrypoint = [ "/bin/${cfg.pname}" ];
+    Cmd = [ "run" ];
+    WorkingDir = "/data";
+    Volumes = { "/data" = { }; };
+  };
+}

--- a/nix/pkgs/opa-envoy-plugin/pkg.nix
+++ b/nix/pkgs/opa-envoy-plugin/pkg.nix
@@ -1,0 +1,49 @@
+{
+  fetchFromGitHub,
+  buildGoModule                                               # NOTE (3)
+}:
+let
+  gitTag = "v0.53.1-envoy";                                   # NOTE (1)
+  pkgVer = "0.53.1-envoy";
+in buildGoModule rec {
+  pname = "opa-envoy-plugin";
+  version = pkgVer;
+  src = fetchFromGitHub {
+    owner = "open-policy-agent";
+    repo = "opa-envoy-plugin";
+    rev = gitTag;
+    sha256 = "sha256-ng5hPk2R59OrB6PovhtbrPx+/dOFG4uiexQdPxyZfls=";
+  };
+  vendorSha256 = null;
+  subPackages = [ "cmd/opa-envoy-plugin" ];
+
+  CGO_ENABLED = 0;                                            # NOTE (2)
+  WASM_ENABLED = 0;
+  ldflags = [
+    "-X github.com/open-policy-agent/opa/version.Version=${gitTag}"
+  ];
+
+  postConfigure = ''
+    go generate ./...
+  '';
+}
+# NOTE
+# ----
+# 1. How to update this package. Usual procedure but remember to set
+# the src hash to `sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`
+# intially to force downloading Go sources. Because there's a vendor
+# folder, `vendorSha256` needs to be `null`. In fact, `buildGoModule`
+# warns you about it
+#   vendor folder exists, please set
+#   'vendorHash = null;' or 'vendorSha256 = null;
+#
+# 2. Build flags. To figure out what to do, look at their `Makefile`.
+# `buildGoModule` already sets `GOFLAGS=-mod=vendor`, `GO111MODULE=on`
+# and `GOPROXY=off`. `CGO_ENABLED` and `WASM_ENABLED` we set ourselves
+# whereas the remaining setting we don't really need them.
+#
+# 3. gomod2nix. That's usually a better option than buildGoModule but
+# I couldn't manage to make it build the `opa-envoy-plugin` binary.
+# The one issue I couldn't work out is that the code uses both modules
+# and vendoring it seems, so I get this error when building with
+# `buildGoApplication`: `cannot query module due to -mod=vendor`.

--- a/nix/pkgs/opa-envoy-plugin/pkg.nix
+++ b/nix/pkgs/opa-envoy-plugin/pkg.nix
@@ -3,15 +3,14 @@
   buildGoModule                                               # NOTE (3)
 }:
 let
-  gitTag = "v0.53.1-envoy";                                   # NOTE (1)
-  pkgVer = "0.53.1-envoy";
+  cfg = import ./config.nix;                                  # NOTE (1)
 in buildGoModule rec {
-  pname = "opa-envoy-plugin";
-  version = pkgVer;
+  pname = cfg.pname;
+  version = cfg.pkgVer;
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa-envoy-plugin";
-    rev = gitTag;
+    rev = cfg.gitTag;
     sha256 = "sha256-ng5hPk2R59OrB6PovhtbrPx+/dOFG4uiexQdPxyZfls=";
   };
   vendorSha256 = null;
@@ -20,7 +19,7 @@ in buildGoModule rec {
   CGO_ENABLED = 0;                                            # NOTE (2)
   WASM_ENABLED = 0;
   ldflags = [
-    "-X github.com/open-policy-agent/opa/version.Version=${gitTag}"
+    "-X github.com/open-policy-agent/opa/version.Version=${cfg.gitTag}"
   ];
 
   postConfigure = ''


### PR DESCRIPTION
This PR implements all the bits and pieces we need to use OPA as a policy decision and enforcement point, write RBAC policies to protect RESTful services, identify users through OIDC-compliant IdMs. Details below.

### Policy engine
Rego library (`authnz`) to easily define role-based access control (RBAC) rules to protect RESTful services and then enforce those rules on each HTTP request. Features at a glance:
- Declare RBAC roles, users and rules in plain Rego using an intuitive DB format.
- Easily query the RBAC DB with `authnz` built-in functions or roll out your own Rego queries.
- Choose any OIDC-compliant IdM (e.g. Keycloak) to manage your users and identify them through JSON Web tokens (JWT).
- Let `authnz` handle JWT validation for you---from OIDC discovery to JWKs download to signature verification, `authnz` does it all for your under the bonnet. You can also use a static JWKs though if you like.
- Seamlessly hook your RBAC into the Envoy OPA Plugin to enforce your rules.

### Mesh config
- OPA K8s deployment with policies automatically included in the Argo CD CI/CD pipeline.
- Istio config to use OPA as policy enforcement/decision point on each HTTP request coming through the Istio ingress gateway, except for requests to Argo CD and Keycloak---these two already manage security on their own.
- Our security setup works even on `localhost` deployments---no need to fiddle w/ e.g. DNS/hosts file.

### ARM support
- ARM 64 OPA Envoy Plugin. OPA don't release an ARM 64 build, so we build our own one w/ Nix.
- ARM 64 OPA Envoy Plugin Docker image. OPA don't release an ARM 64 image, so build our own one w/ Nix.
- ARM 64 OPA Envoy Plugin Docker image K8s preloading. We preload our own custom-built image if the K8s cluster is running on ARM 64.

### Dev shell
Added the following tools
- curl `8.1.1`
- jq `1.6`
- opa `0.53.1`
- opa-envoy-plugin `0.53.1`

### Built-in demo
HttpBin comes with an example policy to restrict access to some resources. The policy grants different access level to two users. These two users come preloaded in a Keycloak realm called `teadal`. This way we can easily demo our security setup after bootstrapping the cluster with no additional config or K8s fiddling.