### PR TITLE
FDP cumulative fixes

### DIFF
--- a/deployment/mesh-infra/security/opa/kustomization.yaml
+++ b/deployment/mesh-infra/security/opa/kustomization.yaml
@@ -14,6 +14,8 @@ secretGenerator:
   - authnz.oidc.rego=rego/authnz/oidc.rego
   - authnz.rbac.rego=rego/authnz/rbac.rego
   - config.oidc.rego=rego/config/oidc.rego
+  - fdpdummy.service.rego=rego/fdpdummy/service.rego
+  - fdpdummy.rbacdb.rego=rego/fdpdummy/rbacdb.rego
   - httpbin.service.rego=rego/httpbin/service.rego
   - httpbin.rbacdb.rego=rego/httpbin/rbacdb.rego
   - minio.service.rego=rego/minio/service.rego

--- a/deployment/mesh-infra/security/opa/rego/fdpdummy/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/fdpdummy/rbacdb.rego
@@ -1,0 +1,39 @@
+#
+# Example RBAC DB.
+# Replace with yours or import is as an external data bundle---e.g.
+# by making OPA download a tarball from a Web server or by linking
+# it from a local disk.
+#
+
+package fdpdummy.rbacdb
+
+import data.authnz.http as http
+
+
+# Role defs.
+product_owner := "product_owner"
+product_consumer := "product_consumer"
+
+# Map each role to a list of permission objects.
+# Each permission object specifies a set of allowed HTTP methods for
+# the Web resources identified by the URLs matching the given regex.
+role_to_perms := {
+    product_owner: [
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/fdp/.*"
+        }
+    ],
+    product_consumer: [
+        {
+            "methods": http.read,
+            "url_regex": "^/fdp/patients/age"
+        }
+    ]
+}
+
+# Map each user to their roles.
+user_to_roles := {
+    "jeejee@teadal.eu": [ product_owner, product_consumer ],
+    "sebs@teadal.eu": [ product_consumer ]
+}

--- a/deployment/mesh-infra/security/opa/rego/fdpdummy/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/fdpdummy/service.rego
@@ -1,0 +1,20 @@
+#
+# Example policy for the dummy FDP.
+#
+
+package fdpdummy.service
+
+import input.attributes.request.http as http_request
+import data.authnz.envopa as envopa
+import data.config.oidc as oidc_config
+import data.fdpdummy.rbacdb as rbac_db
+
+
+default allow := false
+
+allow = true {
+    user := envopa.allow(rbac_db, oidc_config)
+
+    # Put below this line any service-specific checks on e.g. http_request
+
+}

--- a/deployment/mesh-infra/security/opa/rego/main.rego
+++ b/deployment/mesh-infra/security/opa/rego/main.rego
@@ -10,11 +10,18 @@
 #
 package teadal
 
+import data.fdpdummy.service as fdpdummy
 import data.httpbin.service as httpbin
 import data.minio.service as minio
 
 
 default allow := false
+
+allow {
+    fdpdummy.allow
+}
+
+# or
 
 allow {
     httpbin.allow

--- a/deployment/pilot-services/fdp-dummy/base.yaml
+++ b/deployment/pilot-services/fdp-dummy/base.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 80
-    targetPort: 80
+    port: 8080
+    targetPort: 8080
   selector:
     app: fdp-dummy
 
@@ -48,7 +48,7 @@ spec:
           - name: data
             mountPath: /tmp/patients.json
             subPath: patients.json
-        command: ["sh", "-c", "mc alias set rawdata http://teadal-hl.minio-operator.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && mc mb raw/teadal && mc --insecure cp /tmp/patients.json rawdata/teadal/patients.json"]
+        command: ["sh", "-c", "mc alias set rawdata http://teadal-teadal-0.teadal-hl.minio-operator.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && mc mb rawdata/teadal && mc --insecure cp /tmp/patients.json rawdata/teadal/patients.json"]
       restartPolicy: Never
 ---
 apiVersion: apps/v1
@@ -70,9 +70,13 @@ spec:
       containers:
         - name: fdp-dummy
           image: polimiis/teadal-base-fdp-sync
+          ports:
+          - containerPort: 8080
           env: #  Not ideal to hardcode the minio credentials, but we can't mount secrets from a different namespace so ...
-          - name: MINIO_ENDPOINT
-            value: "http://teadal-hl.minio-operator.svc.cluster.local:9000"
+          - name: MINIO_HOST
+            value: "teadal-teadal-0.teadal-hl.minio-operator.svc.cluster.local"
+          - name: MINIO_PORT
+            value: "9000"
           - name: MINIO_ACCESS_KEY
             value: LTXG5CVY0MXLE0WO75Q6
           - name: MINIO_SECRET_KEY
@@ -80,19 +84,19 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi  
+              memory: 128Mi
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: "http-virtual-service"
+  name: "fdp-virtual-service"
 spec:
   gateways:
   - "teadal-gateway"
   hosts:
   - "*"
   http:
-  - match: 
+  - match:
     - uri:
         prefix: /fdp/
     - uri:
@@ -103,7 +107,7 @@ spec:
     - destination:
         host: fdp-dummy.default.svc.cluster.local
         port:
-          number: 80
+          number: 8080
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -111,7 +115,7 @@ metadata:
   name: dummydata
   namespace: minio-operator
 data:
-  patients.json: |- 
+  patients.json: |-
    [{
     "id" : "d290f1ee-6c54-4b01-90e6-d701748f0851",
     "first_name" : "Marshall",

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -11,6 +11,7 @@ the Teadal cluster. Names & versions below.
 * kubectl `1.27.1`
 * kubectl-directpv `4.0.6`
 * kubectl-minio `5.0.6`
+* mc `RELEASE.2023-05-04T18-10-16Z`
 * istioctl `1.18.0`
 * argocd `2.7.6`
 * kustomize `5.0.3`

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -11,7 +11,7 @@
   git, kubectl, istioctl, argocd, kustomize, kubernetes-helm, open-policy-agent,
   qemu, nixos-rebuild, curl, jq,
 
-  kubectl-directpv, kubectl-minio,
+  kubectl-directpv, kubectl-minio, minio-client,
   opa-envoy-plugin
 }:
 
@@ -52,6 +52,7 @@ rec {
     kubectl           # 1.27.1   (pkgs = nixos-23.05)
     kustomize         # 5.0.3    (pkgs = nixos-23.05)
     kubernetes-helm   # 3.11.3   (pkgs = nixos-23.05)
+    minio-client      # RELEASE.2023-05-04T18-10-16Z (pkgs = nixos-23.05)
     open-policy-agent # 0.53.1   (pkgs = nixos-unstable on 01 Jul 2023)
     opa-envoy-plugin  # 0.53.1   (pkgs = nixos-23.05)
     qemu              # 8.0.0    (pkgs = nixos-23.05)


### PR DESCRIPTION
This PR implement some small fixes to #12 as well as the missing OPA policy setup.

- Routing. FDP Virtual Service was overriding existing HTTP one.
- Deployment config. Polimi's service is actually running on port `8080` instead of documented `80` and its using different env vars under the bonnet. Also there were some typos in the K8s Job command to create a MinIO bucket and upload the JSON content.
- Security policy. Implemented Rego policy similar to existing HttpBin one and fixed nasty bug that was stopping the policy from being evaluated correctly---b/c of a missing `allow` partial rule definition for the policy in `main`.
- MinIO client. Added to the dev shell. It should've been there!