### PR TITLE
External RBAC roles

### DIFF
--- a/deployment/mesh-infra/security/keycloak/base.yaml
+++ b/deployment/mesh-infra/security/keycloak/base.yaml
@@ -86,3 +86,75 @@ spec:
       - name: teadal-realm-bootstrap
         configMap:
           name: teadal-realm-bootstrap
+
+# NOTE
+# ----
+# 1. Resetting Keycloak. Since we import the Teadal realm on startup,
+# you can just zap the contents of the DB directory to start again
+# from a clean slate. Obviously, this is only an option when testing,
+# not in a prod scenario! Anyhoo, if you really want to do this, then
+# you can follow a procedure similar to the one below.
+#
+# $ kubectl scale --replicas=0 deployment/keycloak
+# $ kubectl get pv | grep keycloak | cut -f1 -d' ' \
+#                  | xargs -n1 kubectl describe pv | grep Path:
+#     Path:  /data/d1
+# $ ssh -p 10022 admin@localhost
+# $ ls /data/d1/
+#     keycloakdb.lock.db  keycloakdb.mv.db  keycloakdb.trace.db
+# $ rm /data/d1/key*
+# $ exit
+# $ kubectl scale --replicas=1 deployment/keycloak
+#
+# 2. Teadal realm export. Here's how.
+#
+# $ kustomize build mesh-infra/security/keycloak/ | kubectl delete -f -
+# $ emacs mesh-infra/security/keycloak/base.yaml
+#     replace container args with the following:
+#         - export
+#         - --realm
+#         - teadal
+#         - --users
+#         - realm_file
+#         - --file
+#         - /opt/keycloak/data/h2/teadal-bootstrap.json
+# $ kustomize build mesh-infra/security/keycloak/ | kubectl apply -f -
+# $ kubectl get pod    # wait until export done
+# $ kubectl get pv | grep keycloak | cut -f1 -d' ' \
+#                  | xargs -n1 kubectl describe pv | grep Path:
+#     Path:  /data/d1
+# $ scp -P 10022 \
+#     admin@localhost:/data/d1/teadal-bootstrap.json \
+#     mesh-infra/security/keycloak/teadal-bootstrap.json
+# # ^ can't use `kubectl cp` b/c there's no `tar` in Keycloak image.
+# $ emacs mesh-infra/security/keycloak/base.yaml
+#     put back original container args
+# $ kustomize build mesh-infra/security/keycloak/ | kubectl apply -f -
+#
+# 3. Teadal realm from scratch. To recreate the Teadal realm from
+# scratch, you should
+# - Redeploy Keycloak to make it start w/o realm import.
+# - Reset Keycloak---see note above about it.
+# - Create & populate the Teadal realm.
+# - Export the realm---see note above about it.
+# - Reset Keycloak.
+# - Redeploy Keycloak to make it start w/ realm import as usual.
+#
+# Here's how to create and populate the Teadal realm.
+# - Browse to the admin console and log in with the admin username
+#   and password you set in the Keycloak K8s secret.
+# - Create a new realm called `teadal` and switch to that realm.
+# - Create two users, `jeejee@teadal.eu` (=email, username: `jeejee`)
+#   and `sebs@teadal.eu` (=email, username: `sebs`), both having log-in
+#   enabled and a (non-temp) password of `abc123`. Take care of turning
+#   on the "Email verified" option for both users.
+# - Create a group called `monitor` and make `jeejee@teadal.eu`
+#   a member of that group.
+# - Edit the built-in `profile` client scope to add a "Group Membership"
+#   mapper---select the "By configuration" option after hitting the add
+#   add button. Set the "Token Claim Name" to `roles` and take care to
+#   turn on the "Add to access token" option.
+#   See:
+#   - https://stackoverflow.com/questions/76919561
+#   - https://i.sstatic.net/8wjyX.png
+#

--- a/deployment/mesh-infra/security/keycloak/teadal-bootstrap.json
+++ b/deployment/mesh-infra/security/keycloak/teadal-bootstrap.json
@@ -333,7 +333,15 @@
       } ]
     }
   },
-  "groups" : [ ],
+  "groups" : [ {
+    "id" : "87b58dac-8b99-4b00-b29d-5c964c90f752",
+    "name" : "monitor",
+    "path" : "/monitor",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { },
+    "subGroups" : [ ]
+  } ],
   "defaultRole" : {
     "id" : "ca0a1f1b-e1ed-4ca3-a191-f143e0f8a67c",
     "name" : "default-roles-teadal",
@@ -393,7 +401,7 @@
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-teadal" ],
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/monitor" ]
   }, {
     "id" : "83cd7e76-334a-4010-bc82-d3c93713bb1c",
     "createdTimestamp" : 1696871143126,
@@ -517,7 +525,9 @@
     "publicClient" : true,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
-    "attributes" : { },
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
@@ -543,7 +553,9 @@
     "publicClient" : false,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
-    "attributes" : { },
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
@@ -569,7 +581,9 @@
     "publicClient" : false,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
-    "attributes" : { },
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
@@ -670,6 +684,19 @@
         "access.token.claim" : "true",
         "claim.name" : "updated_at",
         "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "f33d4e7d-3362-4c35-a2a7-b61deea8f494",
+      "name" : "roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-group-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "full.path" : "false",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "roles",
+        "userinfo.token.claim" : "false"
       }
     }, {
       "id" : "53824739-0a1a-4dda-8ec8-8dd1e19d348a",
@@ -915,7 +942,8 @@
       "consentRequired" : false,
       "config" : {
         "id.token.claim" : "true",
-        "access.token.claim" : "true"
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
       }
     } ]
   }, {
@@ -1061,6 +1089,7 @@
       "consentRequired" : false,
       "config" : {
         "multivalued" : "true",
+        "userinfo.token.claim" : "true",
         "user.attribute" : "foo",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
@@ -1126,7 +1155,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper" ]
       }
     }, {
       "id" : "4d1d9932-9f24-4aba-b0dd-595131034e4d",
@@ -1135,7 +1164,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper" ]
       }
     }, {
       "id" : "228bb3d4-93f9-40f8-b6ff-48437cac8a3d",
@@ -1811,8 +1840,12 @@
     "cibaExpiresIn" : "120",
     "cibaAuthRequestedUserHint" : "login_hint",
     "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
     "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
     "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
     "cibaInterval" : "5",
     "realmReusableOtpCode" : "false"
   },

--- a/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
@@ -61,7 +61,7 @@ jwt_user_field_name := "email"
 # string or zap it to make `authnz` only use the roles and user-to-role
 # mappings defined in your RBAC DB.
 #
-# The easiest, but less flexible way of using JWT roles with Keycloak
+# The easiest, but less flexible, way of using JWT roles with Keycloak
 # is to define a group for each role you want to use and then add users
 # to groups. There's a built-in mapper you can use to output an array
 # containing the groups a user is a member of in a JWT field of your
@@ -235,6 +235,7 @@ example_config := {
         "https://localhost": "http://authnz/openid-connect/certs"
     },
     "jwt_user_field_name": "sub",
+    "jwt_roles_field_name": "roles",
     "jwks": {
         "keys": [
             {

--- a/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/config_test.rego
@@ -94,7 +94,8 @@ jwt_user_field_name := "email"
 # 2. Create user `sebs`, member of above groups and w/ (non-temp)
 #    password `abc123`.
 # 3. Edit built-in `profile` client scope to add a "Group Membership"
-#    mapper whose "Token Claim Name" is `roles`.
+#    mapper whose "Token Claim Name" is `roles`, taking care to turn
+#    on the "Add to access token" option.
 #    See:
 #    - https://stackoverflow.com/questions/76919561
 #    - https://i.sstatic.net/8wjyX.png

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -12,5 +12,22 @@ import data.authnz.rbac as rbac
 allow(rbac_db, config) := user {
     payload := oidc.claims(http_request, config)
     user := payload[config.jwt_user_field_name]
-    rbac.check(rbac_db, user, http_request)
+    external_roles := jwt_roles(payload, config.jwt_roles_field_name)  # (1)
+    rbac.check(rbac_db, user, external_roles, http_request)
+}
+# NOTE
+# ----
+# 1. Optional external roles. If the JWT holds no roles for the given user,
+# we still want to go ahead and check the request using whatever roles may
+# be in the RBAC DB. However, Rego conflates assignment with evaluation so
+# we need an extra helper function, `jwt_roles`, to make sure the RHS expr
+# never evaluates to undefined or produces a type error. For instance,
+# `r := "okay" { x := {}["x"]; 1 == 1 }` actually evaluates to undefined.
+#
+
+jwt_roles(payload, roles_field) := [] {
+    not payload[roles_field]
+}
+jtw_roles(payload, roles_field) := roles {
+    roles := payload[roles_field]
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -1,5 +1,38 @@
 #
-# TODO docs
+# authnz library entry point. authnz makes it easy to decide whether
+# to allow an HTTP request or not, based on the credentials and some
+# RBAC rules. On receiving HTTP request data from Envoy, authnz validates
+# the JWT token in the request and then checks if the user named in
+# the token is allowed to make that request. This check happens by
+# looking up user permissions in an RBAC set of rules expressed in
+# Rego.
+#
+# Here's where to find out more about how authnz works:
+#
+# - Typical usage example: `httpbin.service`.
+# - Defining RBAC rules: `authnz.rbacdb`. Keep in mind you can define
+#   roles directly in Rego or keep them in an external IdM where users
+#   are defined. Or you could even mix the two approaches if you like.
+#   See: `authnz.rbacdb` and `authnz.rbacdb_ext`.
+# - JWT validation: `authnz.oidc`. authnz supports both static and
+#   dynamic scenarios with automatic discovery, download and caching
+#   of token issuer's JWKs. Plus, there's a bunch of options to make
+#   it easy to test and debug in isolation (i.e., just Rego code, no
+#   external IdM required) or with a local IdM, e.g., running in a
+#   K8s cluster on your dev box. See: `authnz.config`.
+# - Tweaking authnz behaviour: `authnz.config`.
+#
+# authnz expects the current HTTP request's data to be in an object
+# with the following fields:
+# - `headers.authorization`: Bearer token.
+# - `method`: request's HTTP method.
+# - `path`: path part of the request's URL.
+#
+# authnz expects to find this object at `input.attributes.request.http`.
+# This is the case when using the OPA Envoy plugin with Envoy. But in
+# principle different setups are possible too, even without Envoy. The
+# only requirement is to put the above fields in `input.attributes.request.http`
+# before calling authnz to evaluate the HTTP request.
 #
 
 package authnz.envopa
@@ -9,6 +42,13 @@ import data.authnz.oidc as oidc
 import data.authnz.rbac as rbac
 
 
+# Allow or deny the current HTTP request.
+# Return the user named in the JTW if the request is allowed.
+#
+# Params
+# - rbac_db. The RBAC rules---see the RBAC DB tests for explanations.
+# - config. An object containing authnz config---see the config test
+#   for explanations.
 allow(rbac_db, config) := user {
     payload := oidc.claims(http_request, config)
     user := payload[config.jwt_user_field_name]

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -12,7 +12,7 @@ import data.authnz.rbac as rbac
 allow(rbac_db, config) := user {
     payload := oidc.claims(http_request, config)
     user := payload[config.jwt_user_field_name]
-    external_roles := jwt_roles(payload, config.jwt_roles_field_name)  # (1)
+    external_roles := jwt_roles(payload, config)               # (1)
     rbac.check(rbac_db, user, external_roles, http_request)
 }
 # NOTE
@@ -25,9 +25,13 @@ allow(rbac_db, config) := user {
 # `r := "okay" { x := {}["x"]; 1 == 1 }` actually evaluates to undefined.
 #
 
-jwt_roles(payload, roles_field) := [] {
-    not payload[roles_field]
+jwt_roles(payload, cfg) := [] {
+    # cater for "jwt_roles_field_name" not being present in config.
+    not cfg["jwt_roles_field_name"]
 }
-jtw_roles(payload, roles_field) := roles {
-    roles := payload[roles_field]
+jwt_roles(payload, cfg) := [] {
+    not payload[cfg.jwt_roles_field_name]
+}
+jtw_roles(payload, cfg) := roles {
+    roles := payload[cfg.jwt_roles_field_name]
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -32,6 +32,20 @@ jwt_roles(payload, cfg) := [] {
 jwt_roles(payload, cfg) := [] {
     not payload[cfg.jwt_roles_field_name]
 }
-jtw_roles(payload, cfg) := roles {
+jwt_roles(payload, cfg) := roles {
     roles := payload[cfg.jwt_roles_field_name]
 }
+# NOTE
+# ----
+# 1. Cleaner code. With a newer version of OPA we should be able to
+# take advantage of the `default` keyword for functions to simplify
+# the definition:
+#
+#   default jwt_roles(_) := []
+#   jtw_roles(payload, cfg) := roles {
+#       roles := payload[cfg.jwt_roles_field_name]
+#   }
+#
+# `default` function values don't work in `0.53.1`---the OPA version
+# we've got at the moment:
+# - https://github.com/open-policy-agent/opa/issues/2445

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa_test.rego
@@ -1,0 +1,103 @@
+package authnz.envopa
+
+import data.authnz.oidc as oidc
+import data.authnz.rbacdb_ext as rbac_db
+
+
+oidc_config := {
+    "jwt_user_field_name": "user",
+    "jwt_roles_field_name": "roles",
+    "jwks": oidc.jwks_tasty_config
+}
+
+make_request(path, method, user, roles) := envoy_input {
+    payload := {
+        "iss": "me",
+        "exp": 10000000000,  # 20 Nov 2286 @ 18:46:40 (CET)
+        "user": user,
+        "roles": roles
+    }
+    token := oidc.generate_tasty_token(payload)
+    request := {
+        "headers": {
+            "authorization": oidc.make_bearer_auth(token)
+        },
+        "method": method,
+        "path": path
+    }
+    envoy_input := {
+        "attributes": {
+            "request": {
+                "http": request
+            }
+        }
+    }
+}
+
+test_jwt_roles_no_roles_field_in_config {
+    payload := {
+        "roles": ["r"]
+    }
+    oidc_cfg := {}
+    roles := jwt_roles(payload, oidc_cfg)
+    roles == []
+}
+
+test_jwt_roles_empty_roles_field_in_config {
+    payload := {
+        "roles": ["r"]
+    }
+    oidc_cfg := {
+        "jwt_roles_field_name": ""
+    }
+    roles := jwt_roles(payload, oidc_cfg)
+    roles == []
+}
+
+test_jwt_roles_missing_roles_field_in_payload {
+    payload := { }
+    oidc_cfg := {
+        "jwt_roles_field_name": "roles"
+    }
+    roles := jwt_roles(payload, oidc_cfg)
+    roles == []
+}
+
+test_jwt_roles_when_roles_field_in_payload {
+    payload := {
+        "roles": ["r"]
+    }
+    oidc_cfg := {
+        "jwt_roles_field_name": "roles"
+    }
+    roles := jwt_roles(payload, oidc_cfg)
+    roles == ["r"]
+}
+
+test_product_owner_can_delete {
+    user := allow(rbac_db, oidc_config)
+        with input as make_request(
+            "/httpbin/anything/", "DELETE", "jeejee", ["product_owner"])
+    user == "jeejee"
+}
+
+test_product_consumer_cant_delete {
+    not allow(rbac_db, oidc_config)
+        with input as make_request(
+            "/httpbin/anything/", "DELETE", "sebs", ["product_consumer"])
+}
+
+# NOTE
+# ----
+# 1. Enough tests. We need to check the `allow` function works. But this
+# function delegates all the work to `claims`, `check` and `jwt_roles`.
+# The `claims` and `check` functions are already tested thoroughly in
+# their own packages. In particular, the tests for `check` verify it
+# works in the case of roles only being defined in the RBAC DB, the
+# case of roles being defined only in the IdM and the case where some
+# roles are defined in the RBAC DB whereas some others in the IdM.
+# Plus, the `httpbin` tests verify the `allow` function works in all
+# cases (all URLs, users and perms) when using the RBAC DB without
+# external roles.
+# So what we really need to check here is all the `jwt_roles` branches
+# and `allow` gets to call `check`.

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -27,10 +27,17 @@ role_perms(rbac_db, role) := perms {
 }
 
 # Find all the permissions associated with the given user.
-user_perms(rbac_db, user) := perms {
-    roles := user_roles(rbac_db, user)
+#
+# The external roles param must be an array (never undefined!) holding
+# the names of any roles the user may have been assigned in an external
+# system and that are referenced in the RBAC DB permission definitions.
+# If the array isn't empty, then the contained labels will be added to
+# the roles found in the RBAC DB for the given user.
+#
+user_perms(rbac_db, user, external_roles) := perms {
+    all_roles := array.concat(user_roles(rbac_db, user), external_roles)
     perms := { ps |
-        role := roles[_]
+        role := all_roles[_]
         role_perms := rbac_db.role_to_perms[role]
         ps := role_perms[_]
     }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -29,8 +29,11 @@ role_perms(rbac_db, role) := perms {
 # Find all the permissions associated with the given user.
 user_perms(rbac_db, user) := perms {
     roles := user_roles(rbac_db, user)
-    perm_sets := { rbac_db.role_to_perms[k] | roles[k] }
-    perms := union(perm_sets)
+    perms := { ps |
+        role := roles[_]
+        role_perms := rbac_db.role_to_perms[role]
+        ps := role_perms[_]
+    }
 }
 
 # Check the given user is allowed to carry out the requested operation

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -10,17 +10,23 @@
 package authnz.rbac
 
 
-# Find all the roles associated to the given user.
+# Find all the roles associated with the given user in the RBAC DB.
+# Return an empty list if there's no `user_to_roles` map or the map
+# has no entry for the given user.
+user_roles(rbac_db, user) := [] {
+    not rbac_db.user_to_roles[user]
+}
 user_roles(rbac_db, user) := roles {
+    rbac_db.user_to_roles
     roles := rbac_db.user_to_roles[user]
 }
 
-# Find all the permissions associated the the given role.
+# Find all the permissions associated with the given role.
 role_perms(rbac_db, role) := perms {
     perms := rbac_db.role_to_perms[role]
 }
 
-# Find all the permissions associated the the given user.
+# Find all the permissions associated with the given user.
 user_perms(rbac_db, user) := perms {
     roles := user_roles(rbac_db, user)
     perm_sets := { rbac_db.role_to_perms[k] | roles[k] }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -17,7 +17,6 @@ user_roles(rbac_db, user) := [] {
     not rbac_db.user_to_roles[user]
 }
 user_roles(rbac_db, user) := roles {
-    rbac_db.user_to_roles
     roles := rbac_db.user_to_roles[user]
 }
 

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -58,9 +58,7 @@ user_perms(rbac_db, user, external_roles) := perms {
 # the roles found in the RBAC DB for the given user.
 #
 check(rbac_db, user, external_roles, request) {
-    all_roles := array.concat(user_roles(rbac_db, user), external_roles)
-    role := all_roles[_]
-    perm := rbac_db.role_to_perms[role][_]
+    perm := user_perms(rbac_db, user, external_roles)[_]
     perm.methods[_] == request.method
     regex.match(perm.url_regex, request.path)
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -9,6 +9,14 @@ test_role_lookup {
     user_roles(rbac_db, "sebs") == { "product_consumer" }
 }
 
+test_role_lookup_when_no_user_to_roles_map {
+    user_roles({}, "jeejee") == []
+}
+
+test_role_lookup_when_user_not_in_user_to_roles_map {
+    user_roles(rbac_db, "im-not-there") == []
+}
+
 test_role_perms {
     role_perms(rbac_db, "product_owner") == {
         {
@@ -53,6 +61,9 @@ test_user_perms {
             "url_regex": "^/httpbin/get$"
         }
     }
+    user_perms(rbac_db, "not-there") ==
+        { 1 | 1 == 0 }
+    #   ^ empty set; sadly, {} is an empty object to Rego!
 }
 
 assert_user_can_do_anything_on_path(user, path) {

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -5,8 +5,8 @@ import data.authnz.rbacdb as rbac_db
 
 
 test_role_lookup {
-    user_roles(rbac_db, "jeejee") == { "product_owner", "product_consumer" }
-    user_roles(rbac_db, "sebs") == { "product_consumer" }
+    user_roles(rbac_db, "jeejee") == [ "product_owner", "product_consumer" ]
+    user_roles(rbac_db, "sebs") == [ "product_consumer" ]
 }
 
 test_role_lookup_when_no_user_to_roles_map {
@@ -18,13 +18,13 @@ test_role_lookup_when_user_not_in_user_to_roles_map {
 }
 
 test_role_perms {
-    role_perms(rbac_db, "product_owner") == {
+    role_perms(rbac_db, "product_owner") == [
         {
             "methods": http.do_anything,
             "url_regex": "^/httpbin/anything/.*"
         }
-    }
-    role_perms(rbac_db, "product_consumer") == {
+    ]
+    role_perms(rbac_db, "product_consumer") == [
         {
             "methods": http.read,
             "url_regex": "^/httpbin/anything/.*"
@@ -33,7 +33,7 @@ test_role_perms {
             "methods": http.read,
             "url_regex": "^/httpbin/get$"
         }
-    }
+    ]
 }
 
 test_user_perms {
@@ -67,27 +67,27 @@ test_user_perms {
 }
 
 assert_user_can_do_anything_on_path(user, path) {
-    check(rbac_db, user, {"method": "GET", "path": path})
-    check(rbac_db, user, {"method": "HEAD", "path": path})
-    check(rbac_db, user, {"method": "OPTIONS", "path": path})
-    check(rbac_db, user, {"method": "PUT", "path": path})
-    check(rbac_db, user, {"method": "POST", "path": path})
-    check(rbac_db, user, {"method": "PATCH", "path": path})
-    check(rbac_db, user, {"method": "DELETE", "path": path})
-    check(rbac_db, user, {"method": "CONNECT", "path": path})
-    check(rbac_db, user, {"method": "TRACE", "path": path})
+    check(rbac_db, user, [], {"method": "GET", "path": path})
+    check(rbac_db, user, [], {"method": "HEAD", "path": path})
+    check(rbac_db, user, [], {"method": "OPTIONS", "path": path})
+    check(rbac_db, user, [], {"method": "PUT", "path": path})
+    check(rbac_db, user, [], {"method": "POST", "path": path})
+    check(rbac_db, user, [], {"method": "PATCH", "path": path})
+    check(rbac_db, user, [], {"method": "DELETE", "path": path})
+    check(rbac_db, user, [], {"method": "CONNECT", "path": path})
+    check(rbac_db, user, [], {"method": "TRACE", "path": path})
 }
 
 assert_user_can_only_read_path(user, path) {
-    check(rbac_db, user, {"method": "GET", "path": path})
-    check(rbac_db, user, {"method": "HEAD", "path": path})
-    check(rbac_db, user, {"method": "OPTIONS", "path": path})
-    not check(rbac_db, user, {"method": "PUT", "path": path})
-    not check(rbac_db, user, {"method": "POST", "path": path})
-    not check(rbac_db, user, {"method": "PATCH", "path": path})
-    not check(rbac_db, user, {"method": "DELETE", "path": path})
-    not check(rbac_db, user, {"method": "CONNECT", "path": path})
-    not check(rbac_db, user, {"method": "TRACE", "path": path})
+    check(rbac_db, user, [], {"method": "GET", "path": path})
+    check(rbac_db, user, [], {"method": "HEAD", "path": path})
+    check(rbac_db, user, [], {"method": "OPTIONS", "path": path})
+    not check(rbac_db, user, [], {"method": "PUT", "path": path})
+    not check(rbac_db, user, [], {"method": "POST", "path": path})
+    not check(rbac_db, user, [], {"method": "PATCH", "path": path})
+    not check(rbac_db, user, [], {"method": "DELETE", "path": path})
+    not check(rbac_db, user, [], {"method": "CONNECT", "path": path})
+    not check(rbac_db, user, [], {"method": "TRACE", "path": path})
 }
 
 test_check_perms {

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -35,6 +35,12 @@ test_role_perms {
             "url_regex": "^/httpbin/get$"
         }
     ]
+    role_perms(rbac_db, "external_role") == [
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/X"
+        }
+    ]
 }
 
 test_user_perms {

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_ext_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_ext_test.rego
@@ -1,0 +1,38 @@
+#
+# Test RBAC DB.
+#
+# This test DB is for the scenario where users and roles are defined
+# in an external IdM. Usually you'd define only users in the IdM and
+# roles plus user-to-roles map in the RBAC DB. But you can also define
+# roles in the IdM and map user to roles in the IdM too. In this case,
+# the JWT contains both the user and their roles, so the RBAC DB only
+# needs to associate permissions to those external roles defined in
+# the IdM.
+#
+
+package authnz.rbacdb_ext
+
+import data.authnz.http as http
+
+
+# Map each external role to a set of permission objects.
+# Each permission object specifies a set of allowed HTTP methods for
+# the Web resources identified by the URLs matching the given regex.
+role_to_perms := {
+    "product_owner": [
+        {
+            "methods": http.do_anything,
+            "url_regex": "^/httpbin/anything/.*"
+        }
+    ],
+    "product_consumer": [
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/anything/.*"
+        },
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/get$"
+        }
+    ]
+}

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
@@ -15,13 +15,13 @@ product_consumer := "product_consumer"
 # Each permission object specifies a set of allowed HTTP methods for
 # the Web resources identified by the URLs matching the given regex.
 role_to_perms := {
-    product_owner: {
+    product_owner: [
         {
             "methods": http.do_anything,
             "url_regex": "^/httpbin/anything/.*"
         }
-    },
-    product_consumer: {
+    ],
+    product_consumer: [
         {
             "methods": http.read,
             "url_regex": "^/httpbin/anything/.*"
@@ -30,11 +30,11 @@ role_to_perms := {
             "methods": http.read,
             "url_regex": "^/httpbin/get$"
         }
-    }
+    ]
 }
 
 # Map each user to their roles.
 user_to_roles := {
-    "jeejee": { product_owner, product_consumer },
-    "sebs": { product_consumer }
+    "jeejee": [ product_owner, product_consumer ],
+    "sebs": [ product_consumer ]
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_test.rego
@@ -30,6 +30,12 @@ role_to_perms := {
             "methods": http.read,
             "url_regex": "^/httpbin/get$"
         }
+    ],
+    "external_role": [  # defined in IdM and passed along thru JWT
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/X"
+        }
     ]
 }
 

--- a/deployment/mesh-infra/security/opa/rego/config/oidc.rego
+++ b/deployment/mesh-infra/security/opa/rego/config/oidc.rego
@@ -13,3 +13,4 @@ jwks_preferred_urls := {
 }
 
 jwt_user_field_name := "email"
+jwt_roles_field_name := "roles"

--- a/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
@@ -10,13 +10,14 @@ package httpbin.rbacdb
 import data.authnz.http as http
 
 
-# Role defs.
+# Role defs. There's also a `monitor` group we reference below which
+# is defined in the IdM.
 product_owner := "product_owner"
 product_consumer := "product_consumer"
 
 # Map each role to a list of permission objects.
 # Each permission object specifies a set of allowed HTTP methods for
-# the Web resources identitified by the URLs matching the given regex.
+# the Web resources identified by the URLs matching the given regex.
 role_to_perms := {
     product_owner: [
         {
@@ -33,10 +34,20 @@ role_to_perms := {
             "methods": http.read,
             "url_regex": "^/httpbin/get$"
         }
+    ],
+    "monitor": [
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/ip$"
+        }
     ]
 }
 
 # Map each user to their roles.
+# We don't need to include user-role mappings already defined in the
+# IdM. For example, jeejee is also a member of `monitor` in the IdM.
+# IdM mappings get extracted from the access token and automatically
+# merged in.
 user_to_roles := {
     "jeejee@teadal.eu": [ product_owner, product_consumer ],
     "sebs@teadal.eu": [ product_consumer ]


### PR DESCRIPTION
This PR extends the RBAC framework with the ability to use roles defined in an IdM. Also, docs got updated with examples and tech details about this new feature.

Before this PR, roles were defined in Rego along with the mapping of users to roles. As of this PR, you can also define roles in the IdM where users are kept and use the IdM's tools to associate users to roles.

If you define all your roles in the IdM, then the Rego policy only needs to contain the `role_to_perms` map associating each role defined in the IdM to a list of permission objects. A mixed scenario is also possible, where you define some roles  in the IdM and others in Rego policies. Regardless of the approach, if you manage some (or all) roles in the IdM, then:
- the IdM must generate access tokens that include not only the authenticated user's ID, but also a list of roles the user belongs to; and
- `authnz` must be configured to read both the user ID and the roles from the access token.

This PR implements the code to support this setup. `authnz` now merges any roles extracted from the token with the roles defined for that user in Rego. More precisely, let `R(u)` be the set of roles for a given user `u`, as defined in the `user_to_roles` map within the Rego policy. If `user_to_roles` is not defined, or it contains no entry for user `u`, then `R(u)` is the empty set. Similarly, let `T(u)` be the set of roles found in the access token issued to user `u`. If the token includes no roles, then `T(u)` is also the empty set. The set of roles `authnz` uses to evaluate the policy for user `u` is the union of these two sets: `R(u) ∪ T(u)`.

