### PR TITLE
OPA upgrade

### DIFF
--- a/deployment/mesh-infra/security/opa/opa-envoy-plugin.yaml
+++ b/deployment/mesh-infra/security/opa/opa-envoy-plugin.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: opa
-          image: openpolicyagent/opa:0.53.1-envoy
+          image: openpolicyagent/opa:1.3.0-envoy-1
           securityContext:
             runAsUser: 1111
           volumeMounts:

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -49,7 +49,7 @@ import data.authnz.rbac as rbac
 # - rbac_db. The RBAC rules---see the RBAC DB tests for explanations.
 # - config. An object containing authnz config---see the config test
 #   for explanations.
-allow(rbac_db, config) := user {
+allow(rbac_db, config) := user if {
     payload := oidc.claims(http_request, config)
     user := payload[config.jwt_user_field_name]
     external_roles := jwt_roles(payload, config)               # (1)
@@ -65,14 +65,14 @@ allow(rbac_db, config) := user {
 # `r := "okay" { x := {}["x"]; 1 == 1 }` actually evaluates to undefined.
 #
 
-jwt_roles(payload, cfg) := [] {
+jwt_roles(payload, cfg) := [] if {
     # cater for "jwt_roles_field_name" not being present in config.
     not cfg["jwt_roles_field_name"]
 }
-jwt_roles(payload, cfg) := [] {
+jwt_roles(payload, cfg) := [] if {
     not payload[cfg.jwt_roles_field_name]
 }
-jwt_roles(payload, cfg) := roles {
+jwt_roles(payload, cfg) := roles if {
     roles := payload[cfg.jwt_roles_field_name]
 }
 # NOTE

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa.rego
@@ -65,27 +65,7 @@ allow(rbac_db, config) := user if {
 # `r := "okay" { x := {}["x"]; 1 == 1 }` actually evaluates to undefined.
 #
 
-jwt_roles(payload, cfg) := [] if {
-    # cater for "jwt_roles_field_name" not being present in config.
-    not cfg["jwt_roles_field_name"]
-}
-jwt_roles(payload, cfg) := [] if {
-    not payload[cfg.jwt_roles_field_name]
-}
+default jwt_roles(_, _) := []
 jwt_roles(payload, cfg) := roles if {
     roles := payload[cfg.jwt_roles_field_name]
 }
-# NOTE
-# ----
-# 1. Cleaner code. With a newer version of OPA we should be able to
-# take advantage of the `default` keyword for functions to simplify
-# the definition:
-#
-#   default jwt_roles(_) := []
-#   jtw_roles(payload, cfg) := roles {
-#       roles := payload[cfg.jwt_roles_field_name]
-#   }
-#
-# `default` function values don't work in `0.53.1`---the OPA version
-# we've got at the moment:
-# - https://github.com/open-policy-agent/opa/issues/2445

--- a/deployment/mesh-infra/security/opa/rego/authnz/envopa_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/envopa_test.rego
@@ -10,7 +10,7 @@ oidc_config := {
     "jwks": oidc.jwks_tasty_config
 }
 
-make_request(path, method, user, roles) := envoy_input {
+make_request(path, method, user, roles) := envoy_input if {
     payload := {
         "iss": "me",
         "exp": 10000000000,  # 20 Nov 2286 @ 18:46:40 (CET)
@@ -34,7 +34,7 @@ make_request(path, method, user, roles) := envoy_input {
     }
 }
 
-test_jwt_roles_no_roles_field_in_config {
+test_jwt_roles_no_roles_field_in_config if {
     payload := {
         "roles": ["r"]
     }
@@ -43,7 +43,7 @@ test_jwt_roles_no_roles_field_in_config {
     roles == []
 }
 
-test_jwt_roles_empty_roles_field_in_config {
+test_jwt_roles_empty_roles_field_in_config if {
     payload := {
         "roles": ["r"]
     }
@@ -54,7 +54,7 @@ test_jwt_roles_empty_roles_field_in_config {
     roles == []
 }
 
-test_jwt_roles_missing_roles_field_in_payload {
+test_jwt_roles_missing_roles_field_in_payload if {
     payload := { }
     oidc_cfg := {
         "jwt_roles_field_name": "roles"
@@ -63,7 +63,7 @@ test_jwt_roles_missing_roles_field_in_payload {
     roles == []
 }
 
-test_jwt_roles_when_roles_field_in_payload {
+test_jwt_roles_when_roles_field_in_payload if {
     payload := {
         "roles": ["r"]
     }
@@ -74,14 +74,14 @@ test_jwt_roles_when_roles_field_in_payload {
     roles == ["r"]
 }
 
-test_product_owner_can_delete {
+test_product_owner_can_delete if {
     user := allow(rbac_db, oidc_config)
         with input as make_request(
             "/httpbin/anything/", "DELETE", "jeejee", ["product_owner"])
     user == "jeejee"
 }
 
-test_product_consumer_cant_delete {
+test_product_consumer_cant_delete if {
     not allow(rbac_db, oidc_config)
         with input as make_request(
             "/httpbin/anything/", "DELETE", "sebs", ["product_consumer"])

--- a/deployment/mesh-infra/security/opa/rego/authnz/http_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/http_test.rego
@@ -1,19 +1,19 @@
 package authnz.http
 
-test_read_set {
+test_read_set if {
     read == { "GET", "HEAD", "OPTIONS" }
 }
 
-test_write_set {
+test_write_set if {
     write == { "PUT", "PATCH", "POST", "DELETE" }
 }
 
-test_read_n_write_set {
+test_read_n_write_set if {
     read_n_write ==
         { "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE" }
 }
 
-test_do_anything_set {
+test_do_anything_set if {
     do_anything ==
         { "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE",
           "TRACE", "CONNECT" }

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_jwt_gen_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_jwt_gen_test.rego
@@ -50,7 +50,7 @@ jwks_tasty_config := {
 }
 
 
-generate_tasty_token(payload) := jwt {
+generate_tasty_token(payload) := jwt if {
     header := {
         "alg": "RS256",
         "kid": "k1",
@@ -59,6 +59,6 @@ generate_tasty_token(payload) := jwt {
     jwt := io.jwt.encode_sign(header, payload, rsa_key_pair_jwk)
 }
 
-make_bearer_auth(jwt) := auth {
+make_bearer_auth(jwt) := auth if {
     auth := sprintf("Bearer %s", [jwt])
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/oidc_test.rego
@@ -1,7 +1,7 @@
 package authnz.oidc
 
 
-test_preferred_token_jwks_url_1 {
+test_preferred_token_jwks_url_1 if {
     want := "http://keycloak/realms/master/protocol/openid-connect/certs"
     token_payload := {"iss": "http://localhost/keycloak/realms/master"}
     url_lookup := {
@@ -11,7 +11,7 @@ test_preferred_token_jwks_url_1 {
     got == want
 }
 
-test_preferred_token_jwks_url_2 {
+test_preferred_token_jwks_url_2 if {
     want := "http://oi.dc/certs"
     token_payload := {"iss": "http://localhost:8080"}
     url_lookup := {
@@ -21,7 +21,7 @@ test_preferred_token_jwks_url_2 {
     got == want
 }
 
-test_preferred_token_jwks_url_3 {
+test_preferred_token_jwks_url_3 if {
     want := "http://oi.dc/certs"
     token_payload := {"iss": "http://localhost:8080/"}
     url_lookup := {
@@ -31,7 +31,7 @@ test_preferred_token_jwks_url_3 {
     got == want
 }
 
-test_preferred_token_jwks_url_4 {
+test_preferred_token_jwks_url_4 if {
     want := "http://oi.dc/certs"
     token_payload := {"iss": "http://localhost:8080/p/q?v=1"}
     url_lookup := {
@@ -41,21 +41,21 @@ test_preferred_token_jwks_url_4 {
     got == want
 }
 
-test_token_issuer_config_url_1 {
+test_token_issuer_config_url_1 if {
     want := "https://key.cloak/realms/master/.well-known/openid-configuration"
     token_payload := {"iss": "https://key.cloak/realms/master"}
     got := token_issuer_config_url(token_payload)
     got == want
 }
 
-test_token_issuer_config_url_2 {
+test_token_issuer_config_url_2 if {
     want := "https://key.cloak/realms/master/.well-known/openid-configuration"
     token_payload := {"iss": "https://key.cloak/realms/master/"}
     got := token_issuer_config_url(token_payload)
     got == want
 }
 
-test_token_jwks_preferred_url {
+test_token_jwks_preferred_url if {
     token_payload := {"iss": "http://localhost/keycloak/realms/master"}
     url_lookup := {
         "http://localhost": "http://localhost/keycloak/realms/master/protocol/openid-connect/certs"
@@ -65,7 +65,7 @@ test_token_jwks_preferred_url {
     jwks.keys  # assert present
 }
 
-test_token_jwks_canonical_url {
+test_token_jwks_canonical_url if {
     token_payload := {"iss": "http://localhost/keycloak/realms/master"}
     url_lookup := { }
     jwks := token_jwks(token_payload, url_lookup)
@@ -74,7 +74,7 @@ test_token_jwks_canonical_url {
     jwks.keys  # assert present
 }
 
-test_extract_bearer_token {
+test_extract_bearer_token if {
     dummy_jwt := "header.payload.signature"
     request := {
         "headers": {
@@ -84,7 +84,7 @@ test_extract_bearer_token {
     bearer_token(request) == dummy_jwt
 }
 
-test_extract_token_payload_with_valid_jwt {
+test_extract_token_payload_with_valid_jwt if {
     payload := {
         "sub": "vans",
         "nbf": 3600,        # 1hr since the epoc
@@ -94,7 +94,7 @@ test_extract_token_payload_with_valid_jwt {
     payload == token_payload(token, jwks_tasty_config)
 }
 
-test_extract_token_payload_with_expired_jwt {
+test_extract_token_payload_with_expired_jwt if {
     payload := {
         "sub": "vans",
         "nbf": 3600,        # 1hr since the epoc
@@ -104,7 +104,7 @@ test_extract_token_payload_with_expired_jwt {
     not token_payload(token, jwks_tasty_config)
 }
 
-test_extract_token_payload_with_nbf_in_the_future {
+test_extract_token_payload_with_nbf_in_the_future if {
     payload := {
         "sub": "vans",
         "nbf": 10000000000, # 20 Nov 2286 @ 18:46:40 (CET)
@@ -114,7 +114,7 @@ test_extract_token_payload_with_nbf_in_the_future {
     not token_payload(token, jwks_tasty_config)
 }
 
-test_claims_with_static_jwks {
+test_claims_with_static_jwks if {
     config := {
         "jwks": jwks_tasty_config
     }
@@ -131,7 +131,7 @@ test_claims_with_static_jwks {
     payload == claims(request, config)
 }
 
-test_claims_with_dynamic_jwks {
+test_claims_with_dynamic_jwks if {
     config := {
         "jwks_preferred_urls": {
             "http://mock": "http://mock/jwks"

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -13,15 +13,15 @@ package authnz.rbac
 # Find all the roles associated with the given user in the RBAC DB.
 # Return an empty list if there's no `user_to_roles` map or the map
 # has no entry for the given user.
-user_roles(rbac_db, user) := [] {
+user_roles(rbac_db, user) := [] if {
     not rbac_db.user_to_roles[user]
 }
-user_roles(rbac_db, user) := roles {
+user_roles(rbac_db, user) := roles if {
     roles := rbac_db.user_to_roles[user]
 }
 
 # Find all the permissions associated with the given role.
-role_perms(rbac_db, role) := perms {
+role_perms(rbac_db, role) := perms if {
     perms := rbac_db.role_to_perms[role]
 }
 
@@ -33,7 +33,7 @@ role_perms(rbac_db, role) := perms {
 # If the array isn't empty, then the contained labels will be added to
 # the roles found in the RBAC DB for the given user.
 #
-user_perms(rbac_db, user, external_roles) := perms {
+user_perms(rbac_db, user, external_roles) := perms if {
     all_roles := array.concat(user_roles(rbac_db, user), external_roles)
     perms := { ps |
         role := all_roles[_]
@@ -56,7 +56,7 @@ user_perms(rbac_db, user, external_roles) := perms {
 # If the array isn't empty, then the contained labels will be added to
 # the roles found in the RBAC DB for the given user.
 #
-check(rbac_db, user, external_roles, request) {
+check(rbac_db, user, external_roles, request) if {
     perm := user_perms(rbac_db, user, external_roles)[_]
     perm.methods[_] == request.method
     regex.match(perm.url_regex, request.path)

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -5,20 +5,20 @@ import data.authnz.rbacdb as rbac_db
 import data.authnz.rbacdb_ext as ext_rbac_db
 
 
-test_role_lookup {
+test_role_lookup if {
     user_roles(rbac_db, "jeejee") == [ "product_owner", "product_consumer" ]
     user_roles(rbac_db, "sebs") == [ "product_consumer" ]
 }
 
-test_role_lookup_when_no_user_to_roles_map {
+test_role_lookup_when_no_user_to_roles_map if {
     user_roles({}, "jeejee") == []
 }
 
-test_role_lookup_when_user_not_in_user_to_roles_map {
+test_role_lookup_when_user_not_in_user_to_roles_map if {
     user_roles(rbac_db, "im-not-there") == []
 }
 
-test_role_perms {
+test_role_perms if {
     role_perms(rbac_db, "product_owner") == [
         {
             "methods": http.do_anything,
@@ -43,7 +43,7 @@ test_role_perms {
     ]
 }
 
-test_user_perms {
+test_user_perms if {
     user_perms(rbac_db, "jeejee", []) == {
         {
             "methods": http.do_anything,
@@ -73,7 +73,7 @@ test_user_perms {
     #   ^ empty set; sadly, {} is an empty object to Rego!
 }
 
-test_user_perms_with_external_role {
+test_user_perms_with_external_role if {
     user_perms(rbac_db, "sebs", ["external_role"]) == {
         {
             "methods": http.read,
@@ -96,7 +96,7 @@ test_user_perms_with_external_role {
     }
 }
 
-test_user_perms_with_ext_role_defs {
+test_user_perms_with_ext_role_defs if {
     # NOTE user = "". The user is irrelevant in this scenario since
     # we've got no user-to-roles map, the JWT holds the roles for the
     # user at hand.
@@ -129,7 +129,7 @@ test_user_perms_with_ext_role_defs {
     #   ^ empty set; sadly, {} is an empty object to Rego!
 }
 
-assert_user_can_do_anything_on_path(user, path) {
+assert_user_can_do_anything_on_path(user, path) if {
     check(rbac_db, user, [], {"method": "GET", "path": path})
     check(rbac_db, user, [], {"method": "HEAD", "path": path})
     check(rbac_db, user, [], {"method": "OPTIONS", "path": path})
@@ -141,7 +141,7 @@ assert_user_can_do_anything_on_path(user, path) {
     check(rbac_db, user, [], {"method": "TRACE", "path": path})
 }
 
-assert_user_can_only_read_path(user, path) {
+assert_user_can_only_read_path(user, path) if {
     check(rbac_db, user, [], {"method": "GET", "path": path})
     check(rbac_db, user, [], {"method": "HEAD", "path": path})
     check(rbac_db, user, [], {"method": "OPTIONS", "path": path})
@@ -153,7 +153,7 @@ assert_user_can_only_read_path(user, path) {
     not check(rbac_db, user, [], {"method": "TRACE", "path": path})
 }
 
-test_check_perms {
+test_check_perms if {
     assert_user_can_do_anything_on_path("jeejee", "/httpbin/anything/")
     assert_user_can_only_read_path("sebs", "/httpbin/anything/")
     assert_user_can_only_read_path("jeejee", "/httpbin/get")

--- a/deployment/mesh-infra/security/opa/rego/fdpdummy/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/fdpdummy/service.rego
@@ -12,7 +12,7 @@ import data.fdpdummy.rbacdb as rbac_db
 
 default allow := false
 
-allow = true {
+allow = true if {
     user := envopa.allow(rbac_db, oidc_config)
 
     # Put below this line any service-specific checks on e.g. http_request

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service.rego
@@ -12,13 +12,13 @@ import data.httpbin.rbacdb as rbac_db
 
 default allow := false
 
-allow = true {
+allow = true if {
     user := envopa.allow(rbac_db, oidc_config)
 
     # Put below this line any service-specific checks on e.g. http_request
 
 }
 
-allow = true {
+allow = true if {
     regex.match("^/httpbin/image.*", http_request.path)
 }

--- a/deployment/mesh-infra/security/opa/rego/httpbin/service_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/service_test.rego
@@ -3,7 +3,7 @@ package httpbin.service
 import data.authnz.oidc as oidc
 
 
-jeejees_token := token {
+jeejees_token := token if {
     payload := {
         "email": "jeejee@teadal.eu",
         "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
@@ -12,7 +12,7 @@ jeejees_token := token {
 }
 jeejees_auth := oidc.make_bearer_auth(jeejees_token)
 
-sebs_token := token {
+sebs_token := token if {
     payload := {
         "email": "sebs@teadal.eu",
         "exp": 10000000000  # 20 Nov 2286 @ 18:46:40 (CET)
@@ -26,7 +26,7 @@ oidc_config := {
    "jwks": oidc.jwks_tasty_config
 }
 
-make_request(method, path, auth) := envoy_input {
+make_request(method, path, auth) := envoy_input if {
     envoy_input := {
         "attributes": {
             "request": {
@@ -42,7 +42,7 @@ make_request(method, path, auth) := envoy_input {
     }
 }
 
-assert_user_can_do_anything_on_path(path, user_auth) {
+assert_user_can_do_anything_on_path(path, user_auth) if {
     allow with input as make_request("GET", path, user_auth)
           with data.config.oidc as oidc_config
     allow with input as make_request("HEAD", path, user_auth)
@@ -63,7 +63,7 @@ assert_user_can_do_anything_on_path(path, user_auth) {
           with data.config.oidc as oidc_config
 }
 
-assert_user_can_only_read_path(path, user_auth) {
+assert_user_can_only_read_path(path, user_auth) if {
     allow with input as make_request("GET", path, user_auth)
           with data.config.oidc as oidc_config
     allow with input as make_request("HEAD", path, user_auth)
@@ -84,7 +84,7 @@ assert_user_can_only_read_path(path, user_auth) {
               with data.config.oidc as oidc_config
 }
 
-test_check_perms {
+test_check_perms if {
     assert_user_can_do_anything_on_path("/httpbin/anything/", jeejees_auth)
     assert_user_can_only_read_path("/httpbin/anything/", sebs_auth)
     assert_user_can_only_read_path("/httpbin/get", jeejees_auth)

--- a/deployment/mesh-infra/security/opa/rego/main.rego
+++ b/deployment/mesh-infra/security/opa/rego/main.rego
@@ -17,19 +17,19 @@ import data.minio.service as minio
 
 default allow := false
 
-allow {
+allow if {
     fdpdummy.allow
 }
 
 # or
 
-allow {
+allow if {
     httpbin.allow
 }
 
 # or
 
-allow {
+allow if {
     minio.allow
 }
 

--- a/deployment/mesh-infra/security/opa/rego/minio/service.rego
+++ b/deployment/mesh-infra/security/opa/rego/minio/service.rego
@@ -9,6 +9,6 @@ import input.attributes.request.http as http_request
 
 default allow := false
 
-allow = true {
+allow = true if {
     regex.match("^/minio/.*", http_request.path)
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -57,6 +57,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-opa": {
+      "locked": {
+        "lastModified": 1745075447,
+        "narHash": "sha256-tMf6N+Kv1ik+q/4PkMY6rvMDNQWTwpKjmJM4m4MRZ/Q=",
+        "owner": "NixOs",
+        "repo": "nixpkgs",
+        "rev": "5cc587d124658390d65a28d6b5f9132ef86c157a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOs",
+        "repo": "nixpkgs",
+        "rev": "5cc587d124658390d65a28d6b5f9132ef86c157a",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1688231357,
@@ -78,6 +94,7 @@
         "gomod2nix": "gomod2nix",
         "nixie": "nixie",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-opa": "nixpkgs-opa",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -27,6 +27,8 @@
           istioctl = nixpkgs-unstable.legacyPackages.${system}.istioctl;
           open-policy-agent =
             nixpkgs-opa.legacyPackages.${system}.open-policy-agent;
+          buildGoModule =
+            nixpkgs-opa.legacyPackages.${system}.buildGoModule;
         })
       ];
     };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -5,6 +5,8 @@
     nixpkgs.url = "github:NixOs/nixpkgs/nixos-23.05";
     nixpkgs-unstable.url = "github:NixOs/nixpkgs/645ff62e09d294a30de823cb568e9c6d68e92606";
                                                # ^ nixos-unstable branch on 01 Jul 2023.
+    nixpkgs-opa.url = "github:NixOs/nixpkgs/5cc587d124658390d65a28d6b5f9132ef86c157a";
+                                               # ^ master branch on 19 Apr 2025.
     nixie = {
       url = "github:c0c0n3/nixie";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -15,7 +17,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, nixie, gomod2nix }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-opa, nixie, gomod2nix }:
   let
     inputPkgs = nixpkgs // {
       mkOverlays = system: [
@@ -24,7 +26,7 @@
           argocd = nixpkgs-unstable.legacyPackages.${system}.argocd;
           istioctl = nixpkgs-unstable.legacyPackages.${system}.istioctl;
           open-policy-agent =
-            nixpkgs-unstable.legacyPackages.${system}.open-policy-agent;
+            nixpkgs-opa.legacyPackages.${system}.open-policy-agent;
         })
       ];
     };

--- a/nix/pkgs/cli-tools/pkg.nix
+++ b/nix/pkgs/cli-tools/pkg.nix
@@ -53,7 +53,7 @@ rec {
     kustomize         # 5.0.3    (pkgs = nixos-23.05)
     kubernetes-helm   # 3.11.3   (pkgs = nixos-23.05)
     minio-client      # RELEASE.2023-05-04T18-10-16Z (pkgs = nixos-23.05)
-    open-policy-agent # 0.53.1   (pkgs = nixos-unstable on 01 Jul 2023)
+    open-policy-agent # 1.3.0    (pkgs = master on 19 Apr 2025)
     opa-envoy-plugin  # 0.53.1   (pkgs = nixos-23.05)
     qemu              # 8.0.0    (pkgs = nixos-23.05)
     nixos-rebuild

--- a/nix/pkgs/opa-envoy-plugin/config.nix
+++ b/nix/pkgs/opa-envoy-plugin/config.nix
@@ -1,6 +1,6 @@
 {
-  gitTag  = "v0.53.1-envoy";
-  pkgVer  = "0.53.1-envoy";
+  gitTag  = "v1.3.0-envoy-1";
+  pkgVer  = "1.3.0-envoy-1";
   pname   = "opa-envoy-plugin";
   imgName = "openpolicyagent/opa";
 }

--- a/nix/pkgs/opa-envoy-plugin/pkg.nix
+++ b/nix/pkgs/opa-envoy-plugin/pkg.nix
@@ -11,13 +11,15 @@ in buildGoModule rec {
     owner = "open-policy-agent";
     repo = "opa-envoy-plugin";
     rev = cfg.gitTag;
-    sha256 = "sha256-ng5hPk2R59OrB6PovhtbrPx+/dOFG4uiexQdPxyZfls=";
+    sha256 = "sha256-IJe/JKdsjJ0oJWa35UjxXHiVsm7M1mFwVx5oQ45uuSE=";
   };
-  vendorSha256 = null;
+  vendorHash = null;
   subPackages = [ "cmd/opa-envoy-plugin" ];
 
-  CGO_ENABLED = 0;                                            # NOTE (2)
-  WASM_ENABLED = 0;
+  env = {                                                     # NOTE (2)
+    CGO_ENABLED = 0;
+    WASM_ENABLED = 0;
+  };
   ldflags = [
     "-X github.com/open-policy-agent/opa/version.Version=${cfg.gitTag}"
   ];
@@ -30,8 +32,8 @@ in buildGoModule rec {
 # ----
 # 1. How to update this package. Usual procedure but remember to set
 # the src hash to `sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`
-# intially to force downloading Go sources. Because there's a vendor
-# folder, `vendorSha256` needs to be `null`. In fact, `buildGoModule`
+# initially to force downloading Go sources. Because there's a vendor
+# folder, `vendorHash` needs to be `null`. In fact, `buildGoModule`
 # warns you about it
 #   vendor folder exists, please set
 #   'vendorHash = null;' or 'vendorSha256 = null;


### PR DESCRIPTION
This PR upgrades the whole OPA infra to work with version `1.3.0`. In detail:
- The OPA CLI tool got upgraded to version `1.3.0`.
- All the Rego code got tweaked to make it compile w/ OPA `1.3.0`.
- The OPA Envoy Plugin Nix package got upgraded to version `1.3.0-envoy-1` of the plugin.
- The OPA Envoy Plugin K8s image got upgraded to version `1.3.0-envoy-1`.
