### PR TITLE
Implicit RBAC roles

### DIFF
--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -25,13 +25,61 @@ role_perms(rbac_db, role) := perms if {
     perms := rbac_db.role_to_perms[role]
 }
 
-# Find all the permissions associated with the given user.
+# Find all the permissions associated with the given user. This is,
+# the set of all permissions associated with the user, via roles, in
+# the RBAC DB.
 #
-# The external roles param must be an array (never undefined!) holding
-# the names of any roles the user may have been assigned in an external
-# system and that are referenced in the RBAC DB permission definitions.
-# If the array isn't empty, then the contained labels will be added to
-# the roles found in the RBAC DB for the given user.
+# In detail, we can think of the `role_to_perms` map in the RBAC DB as
+# a function sending a role `r` to a set of permissions `P(r)`, so
+# `role_to_perms(r) = P(r)`. Likewise, there's a function `R` sending
+# each user `u` to the roles they belong to. Then the set of all perms
+# associated with a given user `u` is `U P(r)` with `r ∈ R(u)`. For
+# instance, say user `u1` belongs to roles `r1` and `r2`, so
+# `R(u1) = { r1, r2 }`, and each role has the following permissions:
+# `P(r1) = { p1, p2 }, P(r2) = { p2, p3, p4 }`. Among other users,
+# roles and perms, there's also user `u2` with roles `R(u2) = { r2, r3 }`
+# and `r3`'s perms are `R(r3) = { p5 }`. Picture the situation as a
+# directed graph:
+#
+#                      u1     u2     ...
+#      R ↓            ↙  ↘   ↙  ↘           __.
+#                   r1    r2     r3  ...      |
+#      P ↓         ↙ ↘  ↙ ↙ ↘    ↓            |___ role_to_perms
+#                 p1  p2 p3  p4  p5  ...      |
+#                                           __|
+#
+# Then the set of permissions associated with `u1` is the set of perm
+# nodes you can reach from `u1`, that is `{ p1, p2, p3, p4 }`, whereas
+# `u2`'s perms are: `{ p2, p3, p4, p5 }`.
+#
+# Notice we consider a user the same as a singleton role. That is, we
+# identify each user `u` with a role named `u` and having just `u` as
+# a member. In other words, for each user `u`, `u ∈ R(u)`. This way you
+# can assign permissions directly to a user `u` in the `role_to_perms`
+# map without having to also explicitly list `u` as a role for user `u`
+# in the `user_to_roles` map. For example, while you can write
+#
+#   role_to_perms := {
+#     "joe@some.edu": [
+#       { "methods": ["GET"], "url_regex": "^/stuff/.*" }
+#     ]
+#   }
+#   user_to_roles := {
+#     "joe@some.edu": [ "joe@some.edu" ]
+#   }
+#
+# you can also omit the `user_to_roles` map in this case since user
+# "joe@some.edu" gets automatically associated to role "joe@some.edu"
+# anyway.
+#
+# Params
+# - rbad_db. The RBAC database.
+# - user. The user making the HTTP request to check.
+# - external_roles. Must be an array (never undefined!) holding the
+#   names of any roles the user may have been assigned in an external
+#   system and that are referenced in the RBAC DB permission definitions.
+#   If the array isn't empty, then the contained labels will be added to
+#   the roles found in the RBAC DB for the given user.
 #
 user_perms(rbac_db, user, external_roles) := perms if {
     all_roles := array.concat(user_roles(rbac_db, user), external_roles)

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac.rego
@@ -35,8 +35,9 @@ role_perms(rbac_db, role) := perms if {
 #
 user_perms(rbac_db, user, external_roles) := perms if {
     all_roles := array.concat(user_roles(rbac_db, user), external_roles)
+    all_roles_with_user := array.concat(all_roles, [user])
     perms := { ps |
-        role := all_roles[_]
+        role := all_roles_with_user[_]
         role_perms := rbac_db.role_to_perms[role]
         ps := role_perms[_]
     }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -172,6 +172,8 @@ assert_user_can_read_path_ext_db(user, roles, path) if {
 
 test_check_perms_ext_db if {
     assert_user_can_read_path_ext_db("sebs", [], "/httpbin/ip")
+    assert_user_can_read_path_ext_db(
+        "sebs", ["product_consumer"], "/httpbin/ip")
     not assert_user_can_read_path_ext_db("sebs", [], "/httpbin/get")
     assert_user_can_read_path_ext_db(
         "sebs", ["product_consumer"], "/httpbin/get")

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbac_test.rego
@@ -124,6 +124,12 @@ test_user_perms_with_ext_role_defs if {
             "url_regex": "^/httpbin/get$"
         }
     }
+    user_perms(ext_rbac_db, "", ["sebs"]) == {
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/ip$"
+        }
+    }
     user_perms(ext_rbac_db, "", []) ==
         { 1 | 1 == 0 }
     #   ^ empty set; sadly, {} is an empty object to Rego!
@@ -158,4 +164,15 @@ test_check_perms if {
     assert_user_can_only_read_path("sebs", "/httpbin/anything/")
     assert_user_can_only_read_path("jeejee", "/httpbin/get")
     assert_user_can_only_read_path("sebs", "/httpbin/get")
+}
+
+assert_user_can_read_path_ext_db(user, roles, path) if {
+    check(ext_rbac_db, user, roles, {"method": "GET", "path": path})
+}
+
+test_check_perms_ext_db if {
+    assert_user_can_read_path_ext_db("sebs", [], "/httpbin/ip")
+    not assert_user_can_read_path_ext_db("sebs", [], "/httpbin/get")
+    assert_user_can_read_path_ext_db(
+        "sebs", ["product_consumer"], "/httpbin/get")
 }

--- a/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_ext_test.rego
+++ b/deployment/mesh-infra/security/opa/rego/authnz/rbacdb_ext_test.rego
@@ -34,5 +34,16 @@ role_to_perms := {
             "methods": http.read,
             "url_regex": "^/httpbin/get$"
         }
+    ],
+    # We'd also like user "sebs" to be able to get the IP address.
+    # So we use implicit roles to define an extra perm just for role
+    # "sebs". (With implicit roles each user gets automatically
+    # associated with a role having the same name as the user and
+    # that contains only that user as its member.)
+    "sebs": [
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/ip$"
+        }
     ]
 }

--- a/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
@@ -41,20 +41,34 @@ role_to_perms := {
             "url_regex": "^/httpbin/ip$"
         }
     ],
-    # We'd also like user "sebs@teadal.eu" to be able to get the IP
-    # address. But "sebs@teadal.eu" isn't a member of monitor and he
-    # shouldn't be since policies for other services could use that
-    # role to grant an access level "sebs@teadal.eu" shouldn't have.
-    # So we use implicit roles to define an extra perm just for role
-    # "sebs@teadal.eu". (With implicit roles each user gets automatically
-    # associated with a role having the same name as the user and that
-    # contains only that user as its member.)
+    # No one except for user "sebs@teadal.eu" should be able to GET
+    # UUIDs. But there's no UUID reader role in the IdM and we don't
+    # want to create one just for "sebs@teadal.eu". So we use RBAC
+    # implicit roles to define this perm just for role "sebs@teadal.eu".
+    # (With implicit roles each user gets automatically associated
+    # with a role having the same name as the user and that contains
+    # only that user as its member.)
     "sebs@teadal.eu": [
         {
             "methods": http.read,
-            "url_regex": "^/httpbin/ip$"
+            "url_regex": "^/httpbin/uuid$"
         }
     ]
+    # Implicit roles also come in handy when you want to make an
+    # exception to the rule (or role, rather :-) for a specific
+    # user. For example, say we'd also like user "sebs@teadal.eu"
+    # to be able to get the IP address. But "sebs@teadal.eu" isn't
+    # a member of monitor and he shouldn't be since policies for
+    # other services could use that role to grant an access level
+    # "sebs@teadal.eu" shouldn't have. So we use implicit roles to
+    # define an extra perm just for role "sebs@teadal.eu" as in the
+    # example below.
+    # "sebs@teadal.eu": [
+    #     {
+    #         "methods": http.read,
+    #         "url_regex": "^/httpbin/ip$"
+    #     }
+    # ]
 }
 
 # Map each user to their roles.

--- a/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
+++ b/deployment/mesh-infra/security/opa/rego/httpbin/rbacdb.rego
@@ -35,7 +35,21 @@ role_to_perms := {
             "url_regex": "^/httpbin/get$"
         }
     ],
-    "monitor": [
+    "monitor": [  # monitor role defined in the IdM
+        {
+            "methods": http.read,
+            "url_regex": "^/httpbin/ip$"
+        }
+    ],
+    # We'd also like user "sebs@teadal.eu" to be able to get the IP
+    # address. But "sebs@teadal.eu" isn't a member of monitor and he
+    # shouldn't be since policies for other services could use that
+    # role to grant an access level "sebs@teadal.eu" shouldn't have.
+    # So we use implicit roles to define an extra perm just for role
+    # "sebs@teadal.eu". (With implicit roles each user gets automatically
+    # associated with a role having the same name as the user and that
+    # contains only that user as its member.)
+    "sebs@teadal.eu": [
         {
             "methods": http.read,
             "url_regex": "^/httpbin/ip$"
@@ -48,6 +62,11 @@ role_to_perms := {
 # IdM. For example, jeejee is also a member of `monitor` in the IdM.
 # IdM mappings get extracted from the access token and automatically
 # merged in.
+# Also, there's no need to add a role "sebs@teadal.eu" for "sebs@teadal.eu",
+# since, with implicit roles,
+#   "sebs@teadal.eu": [ product_consumer ]
+# is the same as
+#   "sebs@teadal.eu": [ product_consumer, "sebs@teadal.eu" ]
 user_to_roles := {
     "jeejee@teadal.eu": [ product_owner, product_consumer ],
     "sebs@teadal.eu": [ product_consumer ]

--- a/docs/arch/sec-design/README.md
+++ b/docs/arch/sec-design/README.md
@@ -6,9 +6,12 @@ Security Architecture
   of the security architecture.
 - [Technical design][design]. Software design and technology stack
   adopted to realise the conceptual architecture.
+- [RBAC framework][rbac]. Role-Based Access Control (RBAC) framework
+  for RESTful service access control.
 
 
 
 
 [concept]: ./concept.md
 [design]: ./tech-design.md
+[rbac]: ./rbac.md

--- a/docs/arch/sec-design/rbac.md
+++ b/docs/arch/sec-design/rbac.md
@@ -1,0 +1,252 @@
+RBAC Framework
+--------------
+> R-BAK-ed with love for Teadal :-)
+
+While the [machinery described so far][design] can be used to enforce
+any kind of access control, Teadal also provides a built-in Role-Based
+Access Control (RBAC) framework. This framework dramatically reduces
+the effort needed to implement access control for RESTful services,
+while still leaving policy writers the freedom to extend the base
+framework with service-specific functionality.
+
+
+### Introduction
+
+Data lake users are managed through a federated, [OIDC][oidc]-compliant
+identity management (IdM) service. Consumer services act on behalf
+of users who have proved their identity through IdM-configured procedures
+such as credential challenges, multi-factor authentication, etc. Upon
+successful authentication, the IdM issues an identity token, more
+specifically a [JSON Web Token][jwt] (JWT), which certifies the user's
+identity. Consumer services attach the token to each data product
+service request by means of the [Bearer][bearer] HTTP Authorization
+header. Presently, Teadal deploys [Keycloak][keycloak] as an IdM service,
+although any other OIDC-compliant software could be used too as the
+RBAC framework only requires OIDC-compliance, making no assumption
+about the actual IdM implementation.
+
+RBAC roles, users and policy rules are written in plain Rego. Thus,
+policy writers are empowered with a fully-fledged programming language
+which they can exploit to customise, abstract and reuse their roles
+and policies to an extent that is simply not possible with traditional,
+configuration-based, cloud Identity and Access Management solutions.
+Moreover, policy writers can implement automated Rego tests to verify
+their policies have the desired effect when evaluated or even do that
+interactively, for rapid prototyping, as the OPA runtime has both
+test and read-eval-print loop (REPL) facilities. Extensive, automated
+tests also prevent regression issues where modifying a rule may have
+an unforeseen, unwanted side-effect, possibly leading to a security
+incident. Again, this level of sophistication is extremely expensive,
+in terms of required effort, to attain with traditional Identity and
+Access Management solutions.
+
+The Teadal `authnz` Rego library is a good case in point. Policy
+writers import this library in their code to automatically handle
+the evaluation of RBAC rules, user authentication, JWT validation,
+OIDC discovery as well as cryptographic keys download, verification
+and caching. The library allows policy writers to concentrate on
+defining their own, service-specific access control rules using an
+intuitive format.
+
+
+### Usage example
+
+By way of example, consider securing a simple FDP. The REST service
+exposes patient records as Web resources. There are three paths:
+`/patients` to list and add patients, `/patients/id/` to retrieve
+and delete a particular patient, and `/patients/age` to retrieve
+a list with the ID and age of each patient but nothing else. Also,
+there is a `/status` path which returns the current service status.
+We would like to define two roles. A product owner, which should
+be able to perform a `GET`, `POST` and `DELETE` on any URL path
+starting with `/patients`, and a product consumer, which should
+only be allowed to `GET` patient ages and service status. Moreover,
+we would like to assign both the product owner and consumer roles
+to the user identified by the email of `jeejee@teadal.eu` whereas
+just the product consumer role to the user identified by the email
+of `sebs@teadal.eu`. In the Teadal RBAC framework, all of the above
+can be accomplished with the following Rego code.
+
+```rego
+# Role defs.
+product_owner := "product_owner"
+product_consumer := "product_consumer"
+
+# Map each role to a list of permission objects.
+# Each permission object specifies a set of allowed HTTP methods for
+# the Web resources identified by the URLs matching the given regex.
+role_to_perms := {
+    product_owner: [
+        {
+            "methods": [ "GET", "POST", "DELETE" ],
+            "url_regex": "^/patients/.*"
+        }
+    ],
+    product_consumer: [
+        {
+            "methods": [ "GET" ],
+            "url_regex": "^/patients/age$"
+        },
+        {
+            "methods": [ "GET" ],
+            "url_regex": "^/status$"
+        }
+    ]
+}
+
+# Map each user to their roles.
+user_to_roles := {
+    "jeejee@teadal.eu": [ product_owner, product_consumer ],
+    "sebs@teadal.eu": [ product_consumer ]
+}
+```
+
+To evaluate our RBAC rules against the request received from Envoy,
+we would simply import the Teadal `authnz` library and call its
+`allow` function as exemplified by the Rego code snippet below,
+where we tacitly assume the RBAC rules defined earlier are in
+a package imported as `rbac_db`.
+
+```rego
+default allow := false
+
+allow = true {
+    # Use the `allow` function from `authnz.envopa` to check our RBAC
+    # rules against the HTTP request received from Envoy. The function
+    # returns the user extracted from the JWT if the check is successful.
+    user := envopa.allow(rbac_db)
+
+    # Put below this line any service-specific checks on e.g. the
+    # HTTP request received from Envoy.
+}
+```
+
+As already mentioned, `authnz` automatically handles the evaluation
+of RBAC rules, user authentication, JWT validation, OIDC discovery
+as well as cryptographic keys download, verification and caching.
+Also of note, `authnz` provides built-in functions to evaluate
+user-defined RBAC rules interactively in the Rego REPL. This is
+useful for dry-run scenarios where a policy writer may want to see
+what is the effect of their RBAC rules before deploying them to the
+data lake.
+
+
+### Mapping users to roles
+
+In the previous example, roles were defined in Rego along with the
+mapping of users to roles. It is also possible to define roles in
+the IdM where users are kept and use the IdM's tools to associate
+users to roles. In this case, the Rego policy would only contain the
+`role_to_perms` map associating each role defined in the IdM to a
+list of permission objects as shown in the example below.
+
+```rego
+role_to_perms := {
+    "product_owner": [
+        {
+            "methods": [ "GET", "POST", "DELETE" ],
+            "url_regex": "^/patients/.*"
+        }
+    ],
+    "product_consumer": [
+        {
+            "methods": [ "GET" ],
+            "url_regex": "^/patients/age$"
+        },
+        {
+            "methods": [ "GET" ],
+            "url_regex": "^/status$"
+        }
+    ]
+}
+```
+
+This Rego code defines a policy that has the same effect as that
+presented earlier where users were explicitly associated to roles
+through the `user_to_roles` map.
+
+A mixed scenario is also possible, where some roles are defined in
+the IdM and others in Rego policies—the [Whirlwind Tour][wt] section
+provides an example of this. Regardless of the approach, if some (or
+all) roles are managed in the IdM, then:
+- the IdM must generate access tokens that include not only the
+  authenticated user's ID, but also a list of roles the user
+  belongs to; and
+- `authnz` must be configured to read both the user ID and the
+  roles from the access token.
+
+In this setup, `authnz` merges any roles extracted from the token
+with the roles defined for that user in Rego.
+
+
+### Formal model
+
+We present a simple mathematical model of the RBAC framework. This
+model succinctly and accurately captures how `authnz` handles authentication
+and authorisation using basic set theory and functions. More sophisticated
+and elegant models—such as relation composition, the power-set monad
+with Kleisli composition—could express the same ideas more concisely.
+However, while arguably more powerful, such constructions are likely
+less familiar to most software developers.
+
+We model how `authnz` maps users to roles using a mathematical function.
+Let `R : User ⟶ 𝒫(Role)` be the function that maps a user to a set
+of roles, where both users and roles are uniquely identified by text
+labels. For each user `u`, define `D(u)` as the set of roles assigned
+to `u` in the `user_to_roles` mapping from the RBAC DB. If `user_to_roles`
+is undefined, or contains no entry for `u`, then `D(u)` is the empty
+set `∅`. Similarly, let `T(u)` be the set of roles found in the access
+token issued to `u`. If no roles are present in the token, then `T(u) = ∅`.
+The set of roles that `authnz` uses to evaluate the policy for user
+`u` is the union of these sets and the user identifier as a singleton
+role: `R(u) = D(u) ∪ T(u) ∪ {u}`. As noted earlier, `authnz` identifies
+each user `u` with a role named `u`, consisting only of `u` as its member.
+In other words, for each user `u`, `u ∈ R(u)`.
+
+Similarly, we define a function to model how `authnz` determines the
+permissions associated with a user. This corresponds to the set of
+all permissions linked to the user, via roles, in the RBAC database.
+Specifically, the `role_to_perms` mapping in the RBAC DB can be viewed
+as a function that assigns each role `r` a set of permissions `P(r)`,
+so that `role_to_perms(r) = P(r)`. The set of permissions associated
+with a user `u` is then the union of all `P(r)` for `r ∈ R(u)`. Thus,
+we define a function `K : User ⟶ 𝒫(Perm)` by: `K(u) = ⋃ P(r)` where
+`r ∈ R(u)`.
+
+To illustrate how `K` works, consider the following example. A user
+`u1` belongs to roles `r1` and `r2`, so `R(u1) = { r1, r2 }`. Each
+role has the following permissions: `P(r1) = { p1, p2 }` and
+`P(r2) = { p2, p3, p4 }`. Another user, `u2`, belongs to roles `r2`
+and `r3`, with `P(r3) = { p5 }`. The relationships can be visualized
+as a directed graph, where arrows represent mappings from users to
+roles (`R`) and from roles to permissions (`P`):
+
+```
+                       u1     u2
+       R ↓            ↙  ↘   ↙  ↘       __.
+                    r1    r2     r3       |
+       P ↓         ↙ ↘  ↙ ↙ ↘    ↓        |___ role_to_perms
+                  p1  p2 p3  p4  p5       |
+                                        __|
+```
+
+The set of permissions associated with `u1` is the set of permission
+nodes reachable via a directed path from `u1`, namely `{ p1, p2, p3, p4 }`.
+Similarly, `u2` is associated with `{ p2, p3, p4, p5 }`.
+
+With `K` defined, we can now describe how `authnz` makes policy decisions.
+We model permissions as predicates over HTTP requests, that is, functions
+of the form `p : Req ⟶ Bool`. Then, `authnz` authorises an incoming HTTP
+request `req` if and only if the following two conditions are satisfied:
+- `req` contains a valid JWT token for user `u`;
+- there exists a permission `p ∈ K(u)` such that `p(req) = true`.
+
+
+
+
+[bearer]: https://datatracker.ietf.org/doc/html/rfc6750
+[design]: ./tech-design.md
+[keycloak]: https://www.keycloak.org/
+[jwt]: https://datatracker.ietf.org/doc/html/rfc7519
+[oidc]: https://openid.net/developers/how-connect-works/
+[wt]: ../../whirlwind-tour.md#security

--- a/docs/arch/sec-design/rbac.md
+++ b/docs/arch/sec-design/rbac.md
@@ -273,7 +273,7 @@ roles (`R`) and from roles to permissions (`P`):
 
 ```
                        u1     u2
-       R ↓            ↙  ↘   ↙  ↘       __.
+       R ↓            ↙  ↘   ↙  ↘       __
                     r1    r2     r3       |
        P ↓         ↙ ↘  ↙ ↙ ↘    ↓        |___ role_to_perms
                   p1  p2 p3  p4  p5       |

--- a/docs/arch/sec-design/tech-design.md
+++ b/docs/arch/sec-design/tech-design.md
@@ -14,10 +14,14 @@ for evaluation against consumer requests to perform operations on
 data products.
 
 This section delves into the technical design and technology stack
-adopted to realise the aforementioned conceptual architecture. Note
-that the Teadal security implementation embraces Open Source: all
-the technology stack components, both third-party and Teadal's own,
-are open-source.
+adopted to realise the aforementioned conceptual architecture. A
+[separate section][rbac] is devoted to Teadal's built-in Role-Based
+Access Control (RBAC) framework which can be used to write security
+policies for the policy decision point component to evaluate.
+
+Note that the Teadal security implementation embraces Open Source:
+all the technology stack components, both third-party and Teadal's
+own, are open-source.
 
 
 ### Message interception and access control delegation
@@ -145,238 +149,6 @@ the consumer and produces the same response it would if the proxy
 did not intercept the incoming request.
 
 
-### RBAC framework
-
-While the machinery described so far can be used to enforce any kind
-of access control, Teadal also provides a built-in Role-Based Access
-Control (RBAC) framework. This framework dramatically reduces the
-effort needed to implement access control for RESTful services, while
-still leaving policy writers the freedom to extend the base framework
-with service-specific functionality.
-
-Data lake users are managed through a federated, [OIDC][oidc]-compliant
-identity management (IdM) service. Consumer services act on behalf
-of users who have proved their identity through IdM-configured procedures
-such as credential challenges, multi-factor authentication, etc. Upon
-successful authentication, the IdM issues an identity token, more
-specifically a [JSON Web Token][jwt] (JWT), which certifies the user's
-identity. Consumer services attach the token to each data product
-service request by means of the [Bearer][bearer] HTTP Authorization
-header. Presently, Teadal deploys [Keycloak][keycloak] as an IdM service,
-although any other OIDC-compliant software could be used too as the
-RBAC framework only requires OIDC-compliancy, making no assumption
-about the actual IdM implementation.
-
-RBAC roles, users and policy rules are written in plain Rego. Thus,
-policy writers are empowered with a fully-fledged programming language
-which they can exploit to customise, abstract and reuse their roles
-and policies to an extent that is simply not possible with traditional,
-configuration-based, cloud Identity and Access Management solutions.
-Moreover, policy writers can implement automated Rego tests to verify
-their policies have the desired effect when evaluated or even do that
-interactively, for rapid prototyping, as the OPA runtime has both
-test and read-eval-print loop (REPL) facilities. Extensive, automated
-tests also prevent regression issues where modifying a rule may have
-an unforeseen, unwanted side-effect, possibly leading to a security
-incident. Again, this level of sophistication is extremely expensive,
-in terms of required effort, to attain with traditional Identity and
-Access Management solutions.
-
-The Teadal `authnz` Rego library is a good case in point. Policy
-writers import this library in their code to automatically handle
-the evaluation of RBAC rules, user authentication, JWT validation,
-OIDC discovery as well as cryptographic keys download, verification
-and caching. The library allows policy writers to concentrate on
-defining their own, service-specific access control rules using an
-intuitive format.
-
-By way of example, consider securing a simple FDP. The REST service
-exposes patient records as Web resources. There are three paths:
-`/patients` to list and add patients, `/patients/id/` to retrieve
-and delete a particular patient, and `/patients/age` to retrieve
-a list with the ID and age of each patient but nothing else. Also,
-there is a `/status` path which returns the current service status.
-We would like to define two roles. A product owner, which should
-be able to perform a `GET`, `POST` and `DELETE` on any URL path
-starting with `/patients`, and a product consumer, which should
-only be allowed to `GET` patient ages and service status. Moreover,
-we would like to assign both the product owner and consumer roles
-to the user identified by the email of `jeejee@teadal.eu` whereas
-just the product consumer role to the user identified by the email
-of `sebs@teadal.eu`. In the Teadal RBAC framework, all of the above
-can be accomplished with the following Rego code.
-
-```rego
-# Role defs.
-product_owner := "product_owner"
-product_consumer := "product_consumer"
-
-# Map each role to a list of permission objects.
-# Each permission object specifies a set of allowed HTTP methods for
-# the Web resources identified by the URLs matching the given regex.
-role_to_perms := {
-    product_owner: [
-        {
-            "methods": [ "GET", "POST", "DELETE" ],
-            "url_regex": "^/patients/.*"
-        }
-    ],
-    product_consumer: [
-        {
-            "methods": [ "GET" ],
-            "url_regex": "^/patients/age$"
-        },
-        {
-            "methods": [ "GET" ],
-            "url_regex": "^/status$"
-        }
-    ]
-}
-
-# Map each user to their roles.
-user_to_roles := {
-    "jeejee@teadal.eu": [ product_owner, product_consumer ],
-    "sebs@teadal.eu": [ product_consumer ]
-}
-```
-
-To evaluate our RBAC rules against the request received from Envoy,
-we would simply import the Teadal `authnz` library and call its
-`allow` function as exemplified by the Rego code snippet below,
-where we tacitly assume the RBAC rules defined earlier are in
-a package imported as `rbac_db`.
-
-```rego
-default allow := false
-
-allow = true {
-    # Use the `allow` function from `authnz.envopa` to check our RBAC
-    # rules against the HTTP request received from Envoy. The function
-    # returns the user extracted from the JWT if the check is successful.
-    user := envopa.allow(rbac_db)
-
-    # Put below this line any service-specific checks on e.g. the
-    # HTTP request received from Envoy.
-}
-```
-
-As already mentioned, `authnz` automatically handles the evaluation
-of RBAC rules, user authentication, JWT validation, OIDC discovery
-as well as cryptographic keys download, verification and caching.
-Also of note, `authnz` provides built-in functions to evaluate
-user-defined RBAC rules interactively in the Rego REPL. This is
-useful for dry-run scenarios where a policy writer may want to see
-what is the effect of their RBAC rules before deploying them to the
-data lake.
-
-#### Mapping users to roles
-In the previous example, roles were defined in Rego along with the
-mapping of users to roles. It is also possible to define roles in
-the IdM where users are kept and use the IdM's tools to associate
-users to roles. In this case, the Rego policy would only contain the
-`role_to_perms` map associating each role defined in the IdM to a
-list of permission objects as shown in the example below.
-
-```rego
-role_to_perms := {
-    "product_owner": [
-        {
-            "methods": [ "GET", "POST", "DELETE" ],
-            "url_regex": "^/patients/.*"
-        }
-    ],
-    "product_consumer": [
-        {
-            "methods": [ "GET" ],
-            "url_regex": "^/patients/age$"
-        },
-        {
-            "methods": [ "GET" ],
-            "url_regex": "^/status$"
-        }
-    ]
-}
-```
-
-This Rego code defines a policy that has the same effect as that
-presented earlier where users were explicitly associated to roles
-through the `user_to_roles` map.
-
-A mixed scenario is also possible, where some roles are defined in
-the IdM and others in Rego policies—the [Whirlwind Tour][wt] section
-provides an example of this. Regardless of the approach, if some (or
-all) roles are managed in the IdM, then:
-- the IdM must generate access tokens that include not only the
-  authenticated user's ID, but also a list of roles the user
-  belongs to; and
-- `authnz` must be configured to read both the user ID and the
-  roles from the access token.
-
-In this setup, `authnz` merges any roles extracted from the token
-with the roles defined for that user in Rego.
-
-#### Formal model
-We present a simple mathematical model of the RBAC framework. This
-model succinctly and accurately captures how `authnz` handles authentication
-and authorisation using basic set theory and functions. More sophisticated
-and elegant models—such as relation composition, the power-set monad
-with Kleisli composition—could express the same ideas more concisely.
-However, while arguably more powerful, such constructions are likely
-less familiar to most software developers.
-
-We model how `authnz` maps users to roles using a mathematical function.
-Let `R : User ⟶ 𝒫(Role)` be the function that maps a user to a set
-of roles, where both users and roles are uniquely identified by text
-labels. For each user `u`, define `D(u)` as the set of roles assigned
-to `u` in the `user_to_roles` mapping from the RBAC DB. If `user_to_roles`
-is undefined, or contains no entry for `u`, then `D(u)` is the empty
-set `∅`. Similarly, let `T(u)` be the set of roles found in the access
-token issued to `u`. If no roles are present in the token, then `T(u) = ∅`.
-The set of roles that `authnz` uses to evaluate the policy for user
-`u` is the union of these sets and the user identifier as a singleton
-role: `R(u) = D(u) ∪ T(u) ∪ {u}`. As noted earlier, `authnz` identifies
-each user `u` with a role named `u`, consisting only of `u` as its member.
-In other words, for each user `u`, `u ∈ R(u)`.
-
-Similarly, we define a function to model how `authnz` determines the
-permissions associated with a user. This corresponds to the set of
-all permissions linked to the user, via roles, in the RBAC database.
-Specifically, the `role_to_perms` mapping in the RBAC DB can be viewed
-as a function that assigns each role `r` a set of permissions `P(r)`,
-so that `role_to_perms(r) = P(r)`. The set of permissions associated
-with a user `u` is then the union of all `P(r)` for `r ∈ R(u)`. Thus,
-we define a function `K : User ⟶ 𝒫(Perm)` by: `K(u) = ⋃ P(r)` where
-`r ∈ R(u)`.
-
-To illustrate how `K` works, consider the following example. A user
-`u1` belongs to roles `r1` and `r2`, so `R(u1) = { r1, r2 }`. Each
-role has the following permissions: `P(r1) = { p1, p2 }` and
-`P(r2) = { p2, p3, p4 }`. Another user, `u2`, belongs to roles `r2`
-and `r3`, with `P(r3) = { p5 }`. The relationships can be visualized
-as a directed graph, where arrows represent mappings from users to
-roles (`R`) and from roles to permissions (`P`):
-
-```
-                       u1     u2
-       R ↓            ↙  ↘   ↙  ↘       __.
-                    r1    r2     r3       |
-       P ↓         ↙ ↘  ↙ ↙ ↘    ↓        |___ role_to_perms
-                  p1  p2 p3  p4  p5       |
-                                        __|
-```
-
-The set of permissions associated with `u1` is the set of permission
-nodes reachable via a directed path from `u1`, namely `{ p1, p2, p3, p4 }`.
-Similarly, `u2` is associated with `{ p2, p3, p4, p5 }`.
-
-With `K` defined, we can now describe how `authnz` makes policy decisions.
-We model permissions as predicates over HTTP requests, that is, functions
-of the form `p : Req ⟶ Bool`. Then, `authnz` authorises an incoming HTTP
-request `req` if and only if the following two conditions are satisfied:
-- `req` contains a valid JWT token for user `u`;
-- there exists a permission `p ∈ K(u)` such that `p(req) = true`.
-
-
 ### Alternative policy decision points
 
 The Envoy External Authorization Filter can be connected to any gRPC
@@ -412,21 +184,17 @@ policies to the plug-in at regular intervals.
 
 
 [anubis]: https://github.com/orchestracities/anubis
-[bearer]: https://datatracker.ietf.org/doc/html/rfc6750
 [concept]: ./concept.md
 [envoy]: https://www.envoyproxy.io/
 [ext-authz]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter
 [fiware]: https://www.fiware.org/
 [grpc]: https://en.wikipedia.org/wiki/GRPC
 [istio-arch]: https://istio.io/latest/docs/ops/deployment/architecture/
-[keycloak]: https://www.keycloak.org/
-[jwt]: https://datatracker.ietf.org/doc/html/rfc7519
 [long-poll]: https://datatracker.ietf.org/doc/html/rfc6202
-[oidc]: https://openid.net/developers/how-connect-works/
 [opa]: https://www.openpolicyagent.org/
 [opa-envoy]: https://github.com/open-policy-agent/opa-envoy-plugin
 [protobuf]: https://en.wikipedia.org/wiki/Protocol_Buffers
+[rbac]: ./rbac.md
 [security-overview.dia]: ./istio-opa-security.svg
 [souffle]: https://souffle-lang.github.io/
 [wac]: https://solid.github.io/web-access-control-spec/
-[wt]: ../../whirlwind-tour.md#security

--- a/docs/whirlwind-tour.md
+++ b/docs/whirlwind-tour.md
@@ -255,9 +255,9 @@ the requests below which return `403` for `jeejee@teadal.eu` and
 `200` for `sebs@teadal.eu`.
 
 ```bash
-$ curl -i -X GET localhost/httpbin/ip \
+$ curl -i -X GET localhost/httpbin/uuid \
        -H "Authorization: Bearer ${jeejees_token}"
-$ curl -i -X GET localhost/httpbin/ip \
+$ curl -i -X GET localhost/httpbin/uuid \
        -H "Authorization: Bearer ${sebs_token}"
 ```
 

--- a/docs/whirlwind-tour.md
+++ b/docs/whirlwind-tour.md
@@ -145,7 +145,7 @@ exactly straightforward, so to make sense of the examples below you
 should probably first read about [our security architecture][sec],
 at least the conceptual model section.
 
-We'll use HttbBin to simulate a data product. There's a [policy][httpbin-rbac]
+We'll use HttpBin to simulate a data product. There's a [policy][httpbin-rbac]
 that defines two roles:
 - *Product owner*. The owner may do any kind of HTTP request to URLs
    starting with `/httpbin/anything/`.
@@ -237,10 +237,22 @@ $ curl -i -X GET localhost/httpbin/get \
        -H "Authorization: Bearer ${sebs_token}"
 ```
 
-You should see a `200` response in both cases. Finally, members of
-the `monitor` group should be allowed to `GET /httpbin/ip`. Since
+You should see a `200` response in both cases. Now, members of the
+`monitor` group should be allowed to `GET /httpbin/ip`. Since
 `jeejee@teadal.eu` is a member and `sebs@teadal.eu` is not, the below
 requests should return `200` and `403`, respectively.
+
+```bash
+$ curl -i -X GET localhost/httpbin/ip \
+       -H "Authorization: Bearer ${jeejees_token}"
+$ curl -i -X GET localhost/httpbin/ip \
+       -H "Authorization: Bearer ${sebs_token}"
+```
+
+Finally, `sebs@teadal.eu`, but no one else, should be allowed to
+`GET /httpbin/uuid`. In fact, this is the case as you can see from
+the requests below which return `403` for `jeejee@teadal.eu` and
+`200` for `sebs@teadal.eu`.
 
 ```bash
 $ curl -i -X GET localhost/httpbin/ip \


### PR DESCRIPTION
This PR implements RBAC implicit roles and improves the RBAC framework documentation.

### Implicit roles
As of this PR, `autnz` considers a user the same as a singleton role. That is, we identify each user `u` with a role named `u` and having just `u` as a member. This way you can assign permissions directly to a user `u` in the `role_to_perms` map without having to also explicitly list `u` as a role for user `u` in the `user_to_roles` map. For example, while you can write

```rego
role_to_perms := {
     "joe@some.edu": [
         { "methods": ["GET"], "url_regex": "^/stuff/.*" }
     ]
}
user_to_roles := {
    "joe@some.edu": [ "joe@some.edu" ]
}
```

you can also omit the `user_to_roles` map in this case since user `joe@some.edu` gets automatically associated to role `joe@some.edu` anyway.

Implicit roles come in handy when you want to assign permissions directly to users. For example, say you keep your roles in an external IdM and no one except for user `joe@some.edu` should be able to `GET /stuff/`. But there's no "stuff reader" role in the IdM and you don't want to create one just for `joe@some.edu` . Then you can use RBAC implicit roles to define this perm just for role `joe@some.edu` as shown in the `role_to_perms` map in the previous Rego snippet.

As another example, suppose you want to make an exception to the rule (or role, rather :-) for `joe@some.edu`. There's a "monitor" role defined in the IdM which lets members `GET /metrics`. But `joe@some.edu` isn't a member of monitor and he shouldn't be since policies for other services could use that role to grant an access level `joe@some.edu` shouldn't have. You can use implicit roles to define an extra perm just for `joe@some.edu` as in the example below.

```rego
role_to_perms := {
     "joe@some.edu": [
         { "methods": ["GET"], "url_regex": "^/metrics/.*" }
     ]
}
```

### Docs
The whole RBAC framework documentation got revamped, expanded to cater for implicit roles as well as clarifying some bits and pieces which were sort of obscure in the previous release:
- https://github.com/c0c0n3/teadal.proto/blob/main/docs/arch/sec-design/rbac.md

Also a new section got added to explain accurately the way the RBAC framework works. We use a simple maths model for that, involving basic set theory and functions.